### PR TITLE
Provides access to the Algorithm object from the ProgressEvent objects

### DIFF
--- a/src/org/moeaframework/Executor.java
+++ b/src/org/moeaframework/Executor.java
@@ -805,6 +805,7 @@ public class Executor extends ProblemBuilder {
 					}
 					
 					terminationCondition.initialize(algorithm);
+					progress.setCurrentAlgorithm(algorithm);
 
 					while (!algorithm.isTerminated() &&
 							!terminationCondition.shouldTerminate(algorithm)) {

--- a/src/org/moeaframework/util/progress/ProgressEvent.java
+++ b/src/org/moeaframework/util/progress/ProgressEvent.java
@@ -20,6 +20,7 @@ package org.moeaframework.util.progress;
 import java.io.Serializable;
 
 import org.moeaframework.Executor;
+import org.moeaframework.core.Algorithm;
 
 /**
  * A progress report, including the percent complete, elapsed time, and
@@ -34,6 +35,11 @@ public class ProgressEvent implements Serializable {
 	 */
 	private final Executor executor;
 
+	/**
+	 * The current {@link Algorithm} being run. 
+	 */
+	private final Algorithm currentAlgorithm;
+	
 	/**
 	 * The current seed being evaluated, starting at 1.
 	 */
@@ -88,6 +94,7 @@ public class ProgressEvent implements Serializable {
 	 * Constructs a new progress report with the given values.
 	 * 
 	 * @param executor the executor from which these progress reports originate
+	 * @param algorithm the current algorithm the executor is running
 	 * @param currentSeed the current seed being evaluated, starting at 1
 	 * @param totalSeeds the total number of seeds to be evaluated
 	 * @param isSeedFinished {@code true} if this event was created in response
@@ -103,13 +110,14 @@ public class ProgressEvent implements Serializable {
 	 * @param maxTime the maximum elapsed time per seed in seconds, or
 	 *        {@code -1} if not set
 	 */
-	public ProgressEvent(Executor executor, int currentSeed, int totalSeeds,
-			boolean isSeedFinished, int currentNFE, int maxNFE,
-			double percentComplete, double elapsedTime, double remainingTime,
-			double maxTime) {
+	public ProgressEvent(Executor executor, Algorithm algorithm, 
+			int currentSeed, int totalSeeds, boolean isSeedFinished, 
+			int currentNFE,	int maxNFE, double percentComplete,
+			double elapsedTime, double remainingTime, double maxTime) {
 		super();
 		this.executor = executor;
 		this.currentSeed = currentSeed;
+		this.currentAlgorithm = algorithm;
 		this.totalSeeds = totalSeeds;
 		this.isSeedFinished = isSeedFinished;
 		this.currentNFE = currentNFE;
@@ -127,6 +135,15 @@ public class ProgressEvent implements Serializable {
 	 */
 	public Executor getExecutor() {
 		return executor;
+	}
+
+	/**
+	 * Returns the algorithm that is currently running
+	 * 
+	 * @return the algorithm currently running
+	 */
+	public Algorithm getCurrentAlgorithm() {
+		return currentAlgorithm;
 	}
 
 	/**

--- a/src/org/moeaframework/util/progress/ProgressHelper.java
+++ b/src/org/moeaframework/util/progress/ProgressHelper.java
@@ -20,6 +20,7 @@ package org.moeaframework.util.progress;
 import org.apache.commons.lang3.event.EventListenerSupport;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.moeaframework.Executor;
+import org.moeaframework.core.Algorithm;
 
 /**
  * Helper for notifying {@link ProgressListener}s when the evaluation progress
@@ -45,12 +46,17 @@ public class ProgressHelper {
 	 * The executor using this progress helper.
 	 */
 	private final Executor executor;
+
+	/**
+	 * The current {@link Algorithm} being run. 
+	 */
+	private Algorithm currentAlgorithm;
 	
 	/**
 	 * The current seed being evaluated, starting at 1.
 	 */
 	private int currentSeed;
-	
+
 	/**
 	 * The total number of seeds to be evaluated.
 	 */
@@ -192,6 +198,7 @@ public class ProgressHelper {
 		
 		ProgressEvent event = new ProgressEvent(
 				executor,
+				currentAlgorithm,
 				currentSeed,
 				totalSeeds,
 				isSeedFinished,
@@ -237,6 +244,18 @@ public class ProgressHelper {
 			sendProgressEvent(true);
 		}
 	}
+
+	/**
+	 * Sets the currently running algorithm, so that {@link ProgressEvent}s
+	 * can access the algorithm object.
+	 * 
+	 * @param algorithm - the algorithm that is going to be running
+	 */
+	public void setCurrentAlgorithm(Algorithm algorithm) {
+		this.currentAlgorithm = algorithm;
+		
+	}
+
 	
 	/**
 	 * Increments the current seed and sets NFE to 0.  This method will


### PR DESCRIPTION
I believe this change is necessary in order to allow more flexible runtime dynamics monitoring.

In my situation, I have some very slow evaluation functions (simulations), and I want to be able to show the search algorithm's progress (and what it's found so far) as it progresses (so the user can interactively decide to cancel, etc.)

I thought this small change might be helpful for others in the community, so I thought I would share it back.