### PR TITLE
Adds workflow for releasing new versions

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -61,11 +61,6 @@ jobs:
         run: |
           cat docs/news.md | awk '/## Version ${{ inputs.version }}/{flag=1; next} /##/{flag=0} flag' > dist/release_notes.md
           [ "$(wc -l < dist/release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: Release artifacts
-          path: dist/
       - name: Stage Maven bundle
         if: ${{ inputs.publish_maven }}
         run: |
@@ -109,9 +104,14 @@ jobs:
         if: ${{ inputs.publish_github }}
         run: |
           gh release create "v${{ inputs.version }}" --draft --title "Version ${{ inputs.version }}" --notes-file dist/release_notes.md \
-              MOEAFramework-${{ inputs.version }}.tar.gz \
-              MOEAFramework-${{ inputs.version }}-Demo.jar \
-              MOEAFramework-${{ inputs.version }}-Source.tar.gz \
-              MOEAFramework-${{ inputs.version }}-BeginnersGuidePreview.pdf
+              dist/MOEAFramework-${{ inputs.version }}.tar.gz \
+              dist/MOEAFramework-${{ inputs.version }}-Demo.jar \
+              dist/MOEAFramework-${{ inputs.version }}-Source.tar.gz \
+              dist/MOEAFramework-${{ inputs.version }}-BeginnersGuidePreview.pdf
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Release artifacts
+          path: dist/

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -30,4 +30,25 @@ jobs:
           [ "${{ inputs.version }}" == "${BUILD_VERSION}" ] || (>&2 echo "Version does not match value in build.properties"; exit -1)
           [ "${{ inputs.version }}" == "$(cat README.md | grep '<version>' | tr -d '<>/[:alpha:][:space:]')" ] || (>&2 echo "Version does not match value in README.md"; exit -1)
           [ "${{ inputs.version }}" == "$(cat docs/news.md | grep "## " | head -n 1 | grep -oEi '[0-9]+\.[0-9]+(\.[0-9]+)?')" ] || (>&2 echo "Version does not match value in docs/news.md"; exit -1)
-         
+      - name: Build artifacts
+        run: |
+          ant package-binary
+          ant package-demo
+          ant package-source
+      - name: Generate release notes
+        run: |
+          cat docs/news.md | awk '/## Version ${{ inputs.version }}/{flag=1; next} /##/{flag=0} flag' > dist/release_notes.md
+          [ "$(wc -l < release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Release Bundle
+          path: dist/
+      #- name: Stage GitHub release
+      #  uses: ncipollo/release-action@v1
+      #  with:
+      #    artifacts: "dist/*.tar.gz"
+      #    bodyFile: "dist/release_notes.md"
+      #    name: "Version ${{ inputs.version }}"
+      #    tag: "v${{ inputs.version }}"
+      #    draft: true
+      #    prerelease: true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,8 +26,8 @@ jobs:
           echo "BUILD_VERSION=${version}" >> $GITHUB_ENV
       - name: Validate version number
         run: |
-          echo "${{ inputs.version }}" | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' || >&2 echo "Invalid version number format"
-          [ "${{ inputs.version }}" == "${BUILD_VERSION}" ] || >&2 echo "Version does not match value in build.properties"
-          [ "${{ inputs.version }}" == "$(cat README.md | grep '<version>' | tr -d '<>/[:alpha:][:space:]')" ] || >&2 echo "Version does not match value in README.md"
-          [ "${{ inputs.version }}" == "$(cat docs/news.md | grep "## " | head -n 1 | grep -oEi '[0-9]+\.[0-9]+(\.[0-9]+)?')" ] || >&2 echo "Version does not match value in docs/news.md"
+          echo "${{ inputs.version }}" | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' || (>&2 echo "Invalid version number format"; exit -1)
+          [ "${{ inputs.version }}" == "${BUILD_VERSION}" ] || (>&2 echo "Version does not match value in build.properties"; exit -1)
+          [ "${{ inputs.version }}" == "$(cat README.md | grep '<version>' | tr -d '<>/[:alpha:][:space:]')" ] || (>&2 echo "Version does not match value in README.md"; exit -1)
+          [ "${{ inputs.version }}" == "$(cat docs/news.md | grep "## " | head -n 1 | grep -oEi '[0-9]+\.[0-9]+(\.[0-9]+)?')" ] || (>&2 echo "Version does not match value in docs/news.md"; exit -1)
          

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -35,16 +35,39 @@ jobs:
           ant package-binary
           ant package-demo
           ant package-source
-          ant package-website
-          tar -czf dist/website.tar.gz build
       - name: Generate release notes
         run: |
           cat docs/news.md | awk '/## Version ${{ inputs.version }}/{flag=1; next} /##/{flag=0} flag' > dist/release_notes.md
           [ "$(wc -l < dist/release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Release Bundle
-          path: dist/
+      - name: Stage website
+        run: |
+          ant package-website
+          
+          gh auth setup-git
+          git config --global user.email "${{ secrets.EMAIL }}"
+          git config --global user.name "${{ secrets.USERNAME }}"
+          
+          pushd ..
+          gh repo clone MOEAFramework/Website
+          pushd Website
+          git checkout v${{ inputs.version }} || git checkout -b v${{ inputs.version }}
+          
+          rm -rf *
+          cp -R ../MOEAFramework/build/ .
+          
+          git add .
+          
+          if [[ -n "$(git status -s)" ]]; then
+            git commit -m "Update for v${{ inputs.version }}"
+            git push origin v${{ inputs.version }}
+            gh pr create --head v${{ inputs.version }} --fill --repo MOEAFramework/Website || true
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+      #- uses: actions/upload-artifact@v3
+      #  with:
+      #    name: Release Bundle
+      #    path: dist/
       #- name: Stage GitHub release
       #  uses: ncipollo/release-action@v1
       #  with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -35,10 +35,12 @@ jobs:
           ant package-binary
           ant package-demo
           ant package-source
+          ant package-website
+          tar -czf dist/website.tar.gz build
       - name: Generate release notes
         run: |
           cat docs/news.md | awk '/## Version ${{ inputs.version }}/{flag=1; next} /##/{flag=0} flag' > dist/release_notes.md
-          [ "$(wc -l < release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
+          [ "$(wc -l < dist/release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
       - uses: actions/upload-artifact@v3
         with:
           name: Release Bundle

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -71,7 +71,7 @@ jobs:
           echo -n "${{ secrets.GPG_SIGNING_KEY }}" | base64 --decode | gpg --import
           
           pushd maven
-          gpg -ab ${BUILD_NAME}-${BUILD_VERSION}-pom.xml
+          gpg -ab ${BUILD_NAME}-${BUILD_VERSION}.pom
           gpg -ab ${BUILD_NAME}-${BUILD_VERSION}.jar
           gpg -ab ${BUILD_NAME}-${BUILD_VERSION}-sources.jar
           gpg -ab ${BUILD_NAME}-${BUILD_VERSION}-javadoc.jar

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -7,11 +7,18 @@ on:
         type: string
         description: The version to publish
         required: true
-      stage_release:
-        description: 'Create defat GitHub release'
-        required: true 
+      publish_website:
+        description: 'Create draft Website release'
         default: true
         type: boolean 
+      publish_github:
+        description: 'Create draft GitHub release'
+        default: true
+        type: boolean
+      publish_maven:
+        description: 'Create Maven bundle'
+        default: true
+        type: boolean
 
 jobs:
   stage:
@@ -60,6 +67,7 @@ jobs:
           name: Release artifacts
           path: dist/
       - name: Stage website
+        if: ${{ inputs.publish_website }}
         run: |
           ant package-website
           
@@ -81,7 +89,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
       - name: Stage GitHub release
-        if: ${{ inputs.stage_release }}
+        if: ${{ inputs.publish_github }}
         run: |
           gh release create "v${{ inputs.version }}" --draft --title "Version ${{ inputs.version }}" --notes-file dist/release_notes.md \
               MOEAFramework-${{ inputs.version }}.tar.gz \

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -71,7 +71,10 @@ jobs:
           echo -n "${{ secrets.GPG_SIGNING_KEY }}" | base64 --decode | gpg --import
           
           pushd maven
-          gpg -ab *
+          gpg -ab ${BUILD_NAME}-${BUILD_VERSION}-pom.xml
+          gpg -ab ${BUILD_NAME}-${BUILD_VERSION}.jar
+          gpg -ab ${BUILD_NAME}-${BUILD_VERSION}-sources.jar
+          gpg -ab ${BUILD_NAME}-${BUILD_VERSION}-javadoc.jar
           
           jar -cvf ${BUILD_NAME}-${BUILD_VERSION}-bundle.jar *
       - name: Upload Maven bundle

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -66,6 +66,23 @@ jobs:
         with:
           name: Release artifacts
           path: dist/
+      - name: Stage Maven bundle
+        if: ${{ inputs.publish_maven }}
+        run: |
+          ant package-maven
+          
+          echo -n "${{ secrets.GPG_SIGNING_KEY }}" | base64 --decode | gpg --import
+          
+          pushd maven
+          gpg -ab maven/*
+          
+          jar -cvf ${BUILD_NAME}-${BUILD_VERSION}-bundle.jar *
+      - name: Upload Maven bundle
+        if: ${{ inputs.publish_maven }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Maven bundle
+          path: maven/*-bundle.jar
       - name: Stage website
         if: ${{ inputs.publish_website }}
         run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -7,6 +7,11 @@ on:
         type: string
         description: The version to publish
         required: true
+      stage_release:
+        description: 'Create defat GitHub release'
+        required: true 
+        default: true
+        type: boolean 
 
 jobs:
   stage:
@@ -18,6 +23,13 @@ jobs:
         with:
           java-version: 8
           distribution: temurin
+      - name: Setup Git and GitHub CLI
+        run: |
+          gh auth setup-git
+          git config --global user.email "${{ secrets.EMAIL }}"
+          git config --global user.name "${{ secrets.USERNAME }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
       - name: Get project settings
         run: |
           shortname=$(cat META-INF/build.properties | awk '{split($0,a,"="); if (a[1]=="shortname") print tolower(a[2])}' |  tr -d '[:space:]')
@@ -35,21 +47,21 @@ jobs:
           ant package-binary
           ant package-demo
           ant package-source
+      - name: Download beginners guide
+        run: |
+          wget -O dist/MOEAFramework-${{ inputs.version }}-BeginnersGuidePreview.pdf https://github.com/MOEAFramework/MOEAFramework/releases/download/v3.0/MOEAFramework-3.0-BeginnersGuidePreview.pdf
       - name: Generate release notes
         run: |
           cat docs/news.md | awk '/## Version ${{ inputs.version }}/{flag=1; next} /##/{flag=0} flag' > dist/release_notes.md
           [ "$(wc -l < dist/release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
-      - uses: actions/upload-artifact@v3
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v3
         with:
           name: Release artifacts
           path: dist/
       - name: Stage website
         run: |
           ant package-website
-          
-          gh auth setup-git
-          git config --global user.email "${{ secrets.EMAIL }}"
-          git config --global user.name "${{ secrets.USERNAME }}"
           
           pushd ..
           gh repo clone MOEAFramework/Website
@@ -68,12 +80,13 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
-      #- name: Stage GitHub release
-      #  uses: ncipollo/release-action@v1
-      #  with:
-      #    artifacts: "dist/*.tar.gz"
-      #    bodyFile: "dist/release_notes.md"
-      #    name: "Version ${{ inputs.version }}"
-      #    tag: "v${{ inputs.version }}"
-      #    draft: true
-      #    prerelease: true
+      - name: Stage GitHub release
+        if: ${{ inputs.stage_release }}
+        run: |
+          gh release create "v${{ inputs.version }}" --draft --title "Version ${{ inputs.version }}" --notes-file dist/release_notes.md \
+              MOEAFramework-${{ inputs.version }}.tar.gz \
+              MOEAFramework-${{ inputs.version }}-Demo.jar \
+              MOEAFramework-${{ inputs.version }}-Source.tar.gz \
+              MOEAFramework-${{ inputs.version }}-BeginnersGuidePreview.pdf
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -61,15 +61,17 @@ jobs:
         run: |
           cat docs/news.md | awk '/## Version ${{ inputs.version }}/{flag=1; next} /##/{flag=0} flag' > dist/release_notes.md
           [ "$(wc -l < dist/release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
-      - name: Stage Maven bundle
+      - name: Build Maven artifacts
         if: ${{ inputs.publish_maven }}
         run: |
           ant package-maven
-          
+      - name: Sign Maven artifacts and create bundle
+        if: ${{ inputs.publish_maven }}
+        run: |
           echo -n "${{ secrets.GPG_SIGNING_KEY }}" | base64 --decode | gpg --import
           
           pushd maven
-          gpg -ab maven/*
+          gpg -ab *
           
           jar -cvf ${BUILD_NAME}-${BUILD_VERSION}-bundle.jar *
       - name: Upload Maven bundle

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -39,6 +39,10 @@ jobs:
         run: |
           cat docs/news.md | awk '/## Version ${{ inputs.version }}/{flag=1; next} /##/{flag=0} flag' > dist/release_notes.md
           [ "$(wc -l < dist/release_notes.md)" -gt 0 ] || (>&2 echo "Unable to read release notes from docs/news.md"; exit -1)
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Release artifacts
+          path: dist/
       - name: Stage website
         run: |
           ant package-website
@@ -53,7 +57,7 @@ jobs:
           git checkout v${{ inputs.version }} || git checkout -b v${{ inputs.version }}
           
           rm -rf *
-          cp -R ../MOEAFramework/build/ .
+          cp -R ../MOEAFramework/build/* .
           
           git add .
           
@@ -64,10 +68,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
-      #- uses: actions/upload-artifact@v3
-      #  with:
-      #    name: Release Bundle
-      #    path: dist/
       #- name: Stage GitHub release
       #  uses: ncipollo/release-action@v1
       #  with:

--- a/build.xml
+++ b/build.xml
@@ -489,6 +489,7 @@ Use of these build scripts requires Apache Ant to be installed.  See
 		<jar destfile="${maven}/${artifact}-${version}-javadoc.jar"
 				basedir="${javadoc}" />
 		
+		<!--
 		<exec executable="gpg" failonerror="true">
 			<arg value="-ab" />
 			<arg value="${maven}/${artifact}-${version}.pom" />
@@ -511,6 +512,7 @@ Use of these build scripts requires Apache Ant to be installed.  See
 		
 		<jar destfile="${maven}/${artifact}-${version}-bundle.jar"
 				basedir="${maven}" />
+		-->
 	</target>
 	
 </project>


### PR DESCRIPTION
Adds a GitHub Actions workflow that stages new releases by:

1. Compiling and packaging all the files
2. Building and signing the Maven bundle to be uploaded to `oss.sonatype.org`
3. Creating a PR to update the website
4. Drafting a new release on GitHub with the artifacts

All that remains is clicking a few buttons to merge or publish the staged changes.