### PR TITLE
Remove JMetal as a required dependency

### DIFF
--- a/META-INF/services/org.moeaframework.core.spi.AlgorithmProvider
+++ b/META-INF/services/org.moeaframework.core.spi.AlgorithmProvider
@@ -1,3 +1,3 @@
 org.moeaframework.algorithm.DefaultAlgorithms
 org.moeaframework.algorithm.pisa.PISAAlgorithms
-org.moeaframework.algorithm.jmetal.JMetalAlgorithms
+org.moeaframework.algorithm.jmetal.IndirectJMetalAlgorithms

--- a/auxiliary/maven/pom.xml
+++ b/auxiliary/maven/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.moeaframework</groupId>
@@ -19,7 +17,7 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
-	
+
 	<developers>
 		<developer>
 			<id>dhadka</id>
@@ -31,11 +29,11 @@
 	<scm>
 		<url>https://github.com/MOEAFramework/MOEAFramework</url>
 	</scm>
-	
+
 	<properties>
-	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    	<maven.compiler.source>8</maven.compiler.source>
-    	<maven.compiler.target>8</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -45,14 +43,14 @@
 			<version>1.5.0</version>
 		</dependency>
 		<dependency>
-		    <groupId>commons-io</groupId>
-		    <artifactId>commons-io</artifactId>
-		    <version>2.11.0</version>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.11.0</version>
 		</dependency>
 		<dependency>
-		   <groupId>org.apache.commons</groupId>
-		   <artifactId>commons-text</artifactId>
-		   <version>1.10.0</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.10.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -80,22 +78,22 @@
 			<version>3.3.0</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.uma.jmetal</groupId>
-		    <artifactId>jmetal-algorithm</artifactId>
-		    <version>5.9</version>
-		    <scope>provided</scope>
+			<groupId>org.uma.jmetal</groupId>
+			<artifactId>jmetal-algorithm</artifactId>
+			<version>5.9</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		    <groupId>org.uma.jmetal</groupId>
-		    <artifactId>jmetal-core</artifactId>
-		    <version>5.9</version>
-		    <scope>provided</scope>
+			<groupId>org.uma.jmetal</groupId>
+			<artifactId>jmetal-core</artifactId>
+			<version>5.9</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		    <groupId>org.uma.jmetal</groupId>
-		    <artifactId>jmetal-problem</artifactId>
-		    <version>5.9</version>
-		    <scope>test</scope>
+			<groupId>org.uma.jmetal</groupId>
+			<artifactId>jmetal-problem</artifactId>
+			<version>5.9</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -104,7 +102,7 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	
+
 	<distributionManagement>
 		<repository>
 			<id>ossrh</id>

--- a/auxiliary/maven/pom.xml
+++ b/auxiliary/maven/pom.xml
@@ -75,12 +75,6 @@
 			<version>1.5.3</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>rsyntaxtextarea</artifactId>
 			<version>3.3.0</version>
@@ -89,19 +83,25 @@
 		    <groupId>org.uma.jmetal</groupId>
 		    <artifactId>jmetal-algorithm</artifactId>
 		    <version>5.9</version>
-		    <scope>runtime</scope>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.uma.jmetal</groupId>
 		    <artifactId>jmetal-core</artifactId>
 		    <version>5.9</version>
-		    <scope>runtime</scope>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.uma.jmetal</groupId>
 		    <artifactId>jmetal-problem</artifactId>
 		    <version>5.9</version>
 		    <scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	

--- a/auxiliary/maven/pom.xml
+++ b/auxiliary/maven/pom.xml
@@ -83,13 +83,13 @@
 		    <groupId>org.uma.jmetal</groupId>
 		    <artifactId>jmetal-algorithm</artifactId>
 		    <version>5.9</version>
-		    <scope>test</scope>
+		    <scope>provided</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.uma.jmetal</groupId>
 		    <artifactId>jmetal-core</artifactId>
 		    <version>5.9</version>
-		    <scope>test</scope>
+		    <scope>provided</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.uma.jmetal</groupId>

--- a/auxiliary/maven/pom.xml
+++ b/auxiliary/maven/pom.xml
@@ -89,11 +89,13 @@
 		    <groupId>org.uma.jmetal</groupId>
 		    <artifactId>jmetal-algorithm</artifactId>
 		    <version>5.9</version>
+		    <scope>runtime</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.uma.jmetal</groupId>
 		    <artifactId>jmetal-core</artifactId>
 		    <version>5.9</version>
+		    <scope>runtime</scope>
 		</dependency>
 		<dependency>
 		    <groupId>org.uma.jmetal</groupId>

--- a/build.xml
+++ b/build.xml
@@ -157,7 +157,7 @@ Use of these build scripts requires Apache Ant to be installed.  See
 
 		<copy todir="${base}/lib">
 			<fileset file="${dist}/${shortname}-${version}.jar" />
-			<fileset dir="lib" excludes="junit-*.jar,hamcrest-core-*.jar,checkstyle-*.jar" />
+			<fileset dir="lib" excludes="junit-*.jar,hamcrest-core-*.jar,checkstyle-*.jar,jmetal-*.jar" />
 		</copy>
 
 		<copy todir="${base}/pf">
@@ -290,9 +290,6 @@ Use of these build scripts requires Apache Ant to be installed.  See
 		<unjar dest="${build}" src="lib/rsyntaxtextarea-3.3.0.jar" />
 		<unjar dest="${build}" src="lib/jcommon-1.0.24.jar" />
 		<unjar dest="${build}" src="lib/jfreechart-1.5.3.jar" />
-		<unjar dest="${build}" src="lib/jmetal-algorithm-5.9.jar" />
-		<unjar dest="${build}" src="lib/jmetal-core-5.9.jar" />
-		<unjar dest="${build}" src="lib/jmetal-problem-5.9.jar" />
 		
 		<delete dir="${build}/META-INF/maven" />
 		<delete file="${build}/META-INF/LICENSE.txt" />

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 * [List of Algorithms](algorithms.md)
 * [List of Variation Operators](operators.md)
 * [List of Test Problems](problems.md)
+* [Third-Party Algorithm Providers](providers.md)
 
 ## For Developers
 

--- a/docs/news.md
+++ b/docs/news.md
@@ -3,6 +3,11 @@
 This page documents notable changes introduced in each chronological release of the MOEA Framework.
 
 
+## Version 3.2 (TBD)
+
+  * Removes JMetal library from distributions.  These added ~20 MBs to file sizes and are not required
+    for most uses.
+
 ## Version 3.1 (19 Nov 2022)
 
   * Removes all deprecated methods from `2.x` release.

--- a/docs/news.md
+++ b/docs/news.md
@@ -5,8 +5,9 @@ This page documents notable changes introduced in each chronological release of 
 
 ## Version 3.2 (TBD)
 
-  * Removes JMetal library from distributions.  These added ~20 MBs to file sizes and are not required
-    for most uses.
+  * Removes JMetal as a required dependency at runtime.  Not only does this reduce the jar file size by
+    ~20 MBs, it removes overlapping class names shared by both libraries.
+
 
 ## Version 3.1 (19 Nov 2022)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,47 @@
+# Third-Party Algorithm Providers
+
+In addition to the [algorithms built into the MOEA Framework](algorithms.md), we have integrated several
+third-party providers.
+
+## JMetal
+
+JMetal is another Java library for metaheuristic algorithms.  We use it extensively for testing purposes,
+but it also includes several additional algorithms that can be incorporated into the MOEA Framework.
+
+In order to use any JMetal algorithm, one must first setup the JMetal dependencies.  We have built and
+tested against JMetal version **5.9**.
+
+### Maven
+
+If using Maven, add the following dependences to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>org.uma.jmetal</groupId>
+    <artifactId>jmetal-algorithm</artifactId>
+    <version>5.9</version>
+</dependency>
+<dependency>
+    <groupId>org.uma.jmetal</groupId>
+    <artifactId>jmetal-core</artifactId>
+    <version>5.9</version>
+</dependency>
+```
+
+### Manually
+
+Otherwise, download the following JMetal packages and add to the classpath:
+
+1. `jmetal-core` - [Download Jar](https://repo1.maven.org/maven2/org/uma/jmetal/jmetal-core/5.9/jmetal-core-5.9.jar)
+2. `jmetal-algorithm` - [Download Jar](https://repo1.maven.org/maven2/org/uma/jmetal/jmetal-algorithm/5.9/jmetal-algorithm-5.9.jar)
+
+### Supported Algorithms
+
+Refer to [src/org/moeaframework/algorithm/jmetal/JMetalAlgorithms.java] for the full list and available parameters,
+but at the time of writing we support:
+
+1. AbYSS - Hybrid scatter search
+2. CDG - Constrained decomposition MOEA with grid
+3. CellDE - Hybrid cellular genetic algorithm with differential evolution
+4. MOCell - Multi-objective cellular genetic algorithm
+5. MOCHC - Conservative selection combined with a highly-disruptive recombination operator

--- a/src/org/moeaframework/algorithm/jmetal/IndirectJMetalAlgorithms.java
+++ b/src/org/moeaframework/algorithm/jmetal/IndirectJMetalAlgorithms.java
@@ -1,0 +1,15 @@
+package org.moeaframework.algorithm.jmetal;
+
+import org.moeaframework.core.spi.IndirectAlgorithmProvider;
+
+/**
+ * Allows dynamically loading JMetal algorithms without creating a runtime dependency on JMetal.
+ */
+public class IndirectJMetalAlgorithms extends IndirectAlgorithmProvider {
+
+	public IndirectJMetalAlgorithms() {
+		super("org.moeaframework.algorithm.jmetal.JMetalAlgorithms");
+	}
+	
+}
+

--- a/src/org/moeaframework/core/spi/IndirectAlgorithmProvider.java
+++ b/src/org/moeaframework/core/spi/IndirectAlgorithmProvider.java
@@ -1,0 +1,50 @@
+package org.moeaframework.core.spi;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.moeaframework.core.Algorithm;
+import org.moeaframework.core.FrameworkException;
+import org.moeaframework.core.Problem;
+import org.moeaframework.util.TypedProperties;
+
+/**
+ * Algorithm provider that avoids creating runtime dependencies on external libraries.  It accomplishes
+ * this by attempting to load the class dynamically and, if unable to do so, treats it as if
+ * the provider simply does not exist.
+ */
+public class IndirectAlgorithmProvider extends AlgorithmProvider {
+	
+	private final String className;
+	
+	private AlgorithmProvider provider;
+	
+	/**
+	 * Creates an indirect provider for the given algorithm provider.
+	 * 
+	 * @param className the fully-qualified class name for the algorithm provider we want to
+	 *        reference without creating runtime dependencies
+	 */
+	public IndirectAlgorithmProvider(String className) {
+		super();
+		this.className = className;
+	}
+
+	@Override
+	public Algorithm getAlgorithm(String name, TypedProperties properties, Problem problem) {
+		if (provider == null) {
+			try {
+				Class<?> providerType = Class.forName(className);
+				provider = (AlgorithmProvider)providerType.getConstructor().newInstance();
+			} catch (ClassNotFoundException | NoClassDefFoundError e) {
+				return null;
+			} catch (InstantiationException | IllegalAccessException | IllegalArgumentException |
+					InvocationTargetException | NoSuchMethodException | SecurityException e) {
+				throw new FrameworkException(e);
+			}
+		}
+		
+		return provider.getAlgorithm(name, properties, problem);
+	}
+	
+}
+

--- a/src/org/moeaframework/core/spi/IndirectAlgorithmProvider.java
+++ b/src/org/moeaframework/core/spi/IndirectAlgorithmProvider.java
@@ -1,3 +1,20 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.moeaframework.core.spi;
 
 import java.lang.reflect.InvocationTargetException;

--- a/test/org/moeaframework/algorithm/jmetal/IndirectJMetalAlgorithmsTest.java
+++ b/test/org/moeaframework/algorithm/jmetal/IndirectJMetalAlgorithmsTest.java
@@ -23,15 +23,14 @@ import org.moeaframework.problem.MockRealProblem;
 import org.moeaframework.util.TypedProperties;
 
 /**
- * Tests the {@link IndirectJMetalAlgorithms} to ensure the weak class reference
- * is valid.
+ * Tests the {@link IndirectJMetalAlgorithms} to ensure the weak class reference is valid.
  */
 public class IndirectJMetalAlgorithmsTest {
 
 	@Test
 	public void test() {
 		IndirectJMetalAlgorithms provider = new IndirectJMetalAlgorithms();
-		Assert.assertNotNull(provider.getAlgorithm("AbYSS", new TypedProperties(), new MockRealProblem()));
+		Assert.assertNotNull(provider.getAlgorithm("NSGAII-JMetal", new TypedProperties(), new MockRealProblem()));
 	}
 
 }

--- a/test/org/moeaframework/algorithm/jmetal/IndirectJMetalAlgorithmsTest.java
+++ b/test/org/moeaframework/algorithm/jmetal/IndirectJMetalAlgorithmsTest.java
@@ -17,16 +17,21 @@
  */
 package org.moeaframework.algorithm.jmetal;
 
-import org.moeaframework.core.spi.IndirectAlgorithmProvider;
+import org.junit.Assert;
+import org.junit.Test;
+import org.moeaframework.problem.MockRealProblem;
+import org.moeaframework.util.TypedProperties;
 
 /**
- * Allows dynamically loading JMetal algorithms without creating a runtime dependency on JMetal.
+ * Tests the {@link IndirectJMetalAlgorithms} to ensure the weak class reference
+ * is valid.
  */
-public class IndirectJMetalAlgorithms extends IndirectAlgorithmProvider {
+public class IndirectJMetalAlgorithmsTest {
 
-	public IndirectJMetalAlgorithms() {
-		super("org.moeaframework.algorithm.jmetal.JMetalAlgorithms");
+	@Test
+	public void test() {
+		IndirectJMetalAlgorithms provider = new IndirectJMetalAlgorithms();
+		Assert.assertNotNull(provider.getAlgorithm("AbYSS", new TypedProperties(), new MockRealProblem()));
 	}
-	
-}
 
+}

--- a/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
+++ b/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
@@ -36,7 +36,8 @@ public class JMetalReferenceTest {
 	public void testForJMetalReferences() throws IOException {
 		Files.walk(new File("src/").toPath()).forEach((path) -> {
 			if (path.startsWith("src/org/moeaframework/algorithm/jmetal") ||
-					path.startsWith("src/main/java/org/moeaframework/algorithm/jmetal")) {
+					path.startsWith("src/main/java/org/moeaframework/algorithm/jmetal") ||
+					path.startsWith("src/test/")) {
 				return;
 			}
 			

--- a/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
+++ b/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
@@ -35,7 +35,8 @@ public class JMetalReferenceTest {
 	@Test
 	public void testForJMetalReferences() throws IOException {
 		Files.walk(new File("src/").toPath()).forEach((path) -> {
-			if (path.startsWith("src/org/moeaframework/algorithm/jmetal")) {
+			if (path.startsWith("src/org/moeaframework/algorithm/jmetal") ||
+					path.startsWith("src/main/java/org/moeaframework/algorithm/jmetal")) {
 				return;
 			}
 			

--- a/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
+++ b/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
@@ -23,7 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,7 +34,7 @@ public class JMetalReferenceTest {
 
 	@Test
 	public void testForJMetalReferences() throws IOException {
-		Files.walk(Path.of("src/")).forEach((path) -> {
+		Files.walk(new File("src/").toPath()).forEach((path) -> {
 			if (path.startsWith("src/org/moeaframework/algorithm/jmetal")) {
 				return;
 			}

--- a/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
+++ b/test/org/moeaframework/algorithm/jmetal/JMetalReferenceTest.java
@@ -1,0 +1,64 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.algorithm.jmetal;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Scans the src/ tree for any references to JMetal outside of designated packages.
+ */
+public class JMetalReferenceTest {
+
+	@Test
+	public void testForJMetalReferences() throws IOException {
+		Files.walk(Path.of("src/")).forEach((path) -> {
+			if (path.startsWith("src/org/moeaframework/algorithm/jmetal")) {
+				return;
+			}
+			
+			try {
+				assertNoJMetalReference(path.toFile());
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
+	
+	private void assertNoJMetalReference(File file) throws FileNotFoundException, IOException {
+		if (file.isFile() && file.getName().endsWith(".java")) {
+			 try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+				 String line = null;
+				 
+				 while ((line = reader.readLine()) != null) {
+					 if (line.contains("org.uma.jmetal")) {
+						 Assert.fail("Found JMetal reference in " + file);
+					 }
+				 }
+			 }
+		}
+	}
+
+}

--- a/test/org/moeaframework/core/spi/AlgorithmFactoryTest.java
+++ b/test/org/moeaframework/core/spi/AlgorithmFactoryTest.java
@@ -19,11 +19,6 @@ package org.moeaframework.core.spi;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.moeaframework.algorithm.AbstractEvolutionaryAlgorithm;
-import org.moeaframework.core.Algorithm;
-import org.moeaframework.core.Population;
-import org.moeaframework.core.Problem;
-import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.problem.MockRealProblem;
 import org.moeaframework.util.TypedProperties;
 
@@ -35,30 +30,7 @@ public class AlgorithmFactoryTest {
 
 	@Test
 	public void testCustomProvider() {
-		AlgorithmProvider provider = new AlgorithmProvider() {
-
-			@Override
-			public Algorithm getAlgorithm(String name, TypedProperties properties, Problem problem) {
-				if (name.equalsIgnoreCase("testAlgorithm")) {
-					return new AbstractEvolutionaryAlgorithm(
-							problem,
-							new Population(),
-							null,
-							new RandomInitialization(problem, 100)) {
-
-						@Override
-						protected void iterate() {
-							// do nothing
-						}
-						
-					};
-				} else {
-					return null;
-				}
-			}
-			
-		};
-		
+		AlgorithmProvider provider = new TestAlgorithmProvider();
 		AlgorithmFactory originalFactory = AlgorithmFactory.getInstance();
 		
 		AlgorithmFactory factory = new AlgorithmFactory();

--- a/test/org/moeaframework/core/spi/IndirectAlgorithmProviderTest.java
+++ b/test/org/moeaframework/core/spi/IndirectAlgorithmProviderTest.java
@@ -1,0 +1,39 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.spi;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.moeaframework.problem.MockRealProblem;
+import org.moeaframework.util.TypedProperties;
+
+public class IndirectAlgorithmProviderTest {
+	
+	@Test
+	public void test() {
+		Assert.assertNotNull(new IndirectAlgorithmProvider("org.moeaframework.core.spi.TestAlgorithmProvider")
+				.getAlgorithm("testAlgorithm", new TypedProperties(), new MockRealProblem()));
+	}
+	
+	@Test
+	public void testMissingClassName() {
+		Assert.assertNull(new IndirectAlgorithmProvider("foo.bar").getAlgorithm(
+				"foo", new TypedProperties(), new MockRealProblem()));
+	}
+
+}

--- a/test/org/moeaframework/core/spi/TestAlgorithmProvider.java
+++ b/test/org/moeaframework/core/spi/TestAlgorithmProvider.java
@@ -1,0 +1,49 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.spi;
+
+import org.moeaframework.algorithm.AbstractEvolutionaryAlgorithm;
+import org.moeaframework.core.Algorithm;
+import org.moeaframework.core.Population;
+import org.moeaframework.core.Problem;
+import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.util.TypedProperties;
+
+public class TestAlgorithmProvider extends AlgorithmProvider {
+
+	@Override
+	public Algorithm getAlgorithm(String name, TypedProperties properties, Problem problem) {
+		if (name.equalsIgnoreCase("testAlgorithm")) {
+			return new AbstractEvolutionaryAlgorithm(
+					problem,
+					new Population(),
+					null,
+					new RandomInitialization(problem, 100)) {
+
+				@Override
+				protected void iterate() {
+					// do nothing
+				}
+				
+			};
+		} else {
+			return null;
+		}
+	}
+	
+};


### PR DESCRIPTION
Removes JMetal as a required dependency at runtime.  Instead, if one wants or needs to use JMetal, it can be downloaded separately as directed in the docs.  The reasons for this change include:

1. JMetal's core, algorithm, and problem Jars take up about 20 MBs.  This is largely due to the Pareto fronts and weight files that aren't really needed when using the MOEA Framework.
2. JMetal and the MOEA Framework have overlapping class names, such as `Problem`, that can create confusion when IDEs try to suggest imports.  And selecting the wrong one will not work.