### PR TITLE
Add simple constructors for algorithms

### DIFF
--- a/examples/org/moeaframework/examples/prototype/Example.java
+++ b/examples/org/moeaframework/examples/prototype/Example.java
@@ -1,0 +1,34 @@
+package org.moeaframework.examples.prototype;
+import org.moeaframework.algorithm.NSGAII;
+import org.moeaframework.core.NondominatedPopulation;
+import org.moeaframework.core.Problem;
+import org.moeaframework.core.Solution;
+import org.moeaframework.core.operator.real.PCX;
+import org.moeaframework.problem.DTLZ.DTLZ2;
+
+/**
+ * Prototype of the new interface, allowing algorithms to be created and executed
+ * directly.
+ */
+public class Example {
+
+	public static void main(String[] args) {
+		Problem problem = new DTLZ2(2);
+		
+		NSGAII algorithm = new NSGAII(problem);
+		algorithm.setVariation(new PCX(10, 2));
+		algorithm.run(10000);
+
+		NondominatedPopulation result = algorithm.getResult();
+		
+		//display the results
+		System.out.format("Objective1  Objective2%n");
+		
+		for (Solution solution : result) {
+			System.out.format("%.4f      %.4f%n",
+					solution.getObjective(0),
+					solution.getObjective(1));
+		}
+	}
+
+}

--- a/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
@@ -28,6 +28,7 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.Variation;
 
 /**
  * Abstract class providing default implementations for several
@@ -55,6 +56,11 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 	 * The initialization operator.
 	 */
 	protected final Initialization initialization;
+	
+	/**
+	 * The variation operator.
+	 */
+	protected Variation variation;
 
 	/**
 	 * Constructs an abstract evolutionary algorithm.
@@ -63,14 +69,15 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 	 * @param population the population
 	 * @param archive the archive storing the non-dominated solutions
 	 * @param initialization the initialization operator
+	 * @param variation the variation operator
 	 */
-	public AbstractEvolutionaryAlgorithm(Problem problem,
-			Population population, NondominatedPopulation archive,
-			Initialization initialization) {
+	public AbstractEvolutionaryAlgorithm(Problem problem, Population population, NondominatedPopulation archive,
+			Initialization initialization, Variation variation) {
 		super(problem);
 		this.population = population;
 		this.archive = archive;
 		this.initialization = initialization;
+		this.variation = variation;
 	}
 
 	@Override
@@ -112,6 +119,24 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 	@Override
 	public Population getPopulation() {
 		return population;
+	}
+	
+	/**
+	 * Returns the variation operator currently in use by this algorithm.
+	 * 
+	 * @return the variation operator
+	 */
+	public Variation getVariation() {
+		return variation;
+	}
+	
+	/**
+	 * Replaces the variation operator to be used by this algorithm.
+	 * 
+	 * @param variation the variation operator
+	 */
+	protected void setVariation(Variation variation) {
+		this.variation = variation;
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/CMAES.java
+++ b/src/org/moeaframework/algorithm/CMAES.java
@@ -31,6 +31,7 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.AggregateConstraintComparator;
 import org.moeaframework.core.comparator.ChainedComparator;
@@ -199,6 +200,15 @@ public class CMAES extends AbstractAlgorithm {
 	 * Last iteration were the eigenvalue decomposition was calculated.
 	 */
 	private int lastEigenupdate;
+	
+	/**
+	 * Constructs a new CMA-ES intance using default parameters.
+	 * 
+	 * @param problem the problem to optimize
+	 */
+	public CMAES(Problem problem) {
+		this(problem, Settings.DEFAULT_POPULATION_SIZE);
+	}
 	
 	/**
 	 * Constructs a new CMA-ES instance using default parameters.

--- a/src/org/moeaframework/algorithm/DBEA.java
+++ b/src/org/moeaframework/algorithm/DBEA.java
@@ -34,6 +34,8 @@ import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.ObjectiveComparator;
+import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.core.spi.OperatorFactory;
 import org.moeaframework.util.weights.NormalBoundaryDivisions;
 import org.moeaframework.util.weights.NormalBoundaryIntersectionGenerator;
 
@@ -97,14 +99,31 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	Population corner;
 	
 	/**
-	 * The variation operator.
-	 */
-	private final Variation variation;
-	
-	/**
 	 * The number of divisions for generating reference points.
 	 */
 	private final NormalBoundaryDivisions divisions;
+	
+	/**
+	 * Constructs a new instance of the DBEA algorithm with default settings.
+	 * 
+	 * @param problem the problem being solved
+	 */
+	public DBEA(Problem problem) {
+		this(problem, NormalBoundaryDivisions.forProblem(problem));
+	}
+	
+	/**
+	 * Constructs a new instance of the DBEA algorithm with the given number of divisions.
+	 * 
+	 * @param problem the problem being solved
+	 * @param divisions the number of divisions
+	 */
+	public DBEA(Problem problem, NormalBoundaryDivisions divisions) {
+		this(problem,
+				new RandomInitialization(problem, divisions.getNumberOfReferencePoints(problem)),
+				OperatorFactory.getInstance().getVariation(problem),
+				divisions);
+	}
 
 	/**
 	 * Constructs a new instance of the DBEA algorithm.
@@ -116,8 +135,7 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	 */
 	public DBEA(Problem problem, Initialization initialization,
 			Variation variation, NormalBoundaryDivisions divisions) {
-		super(problem, new Population(), null, initialization);
-		this.variation = variation;
+		super(problem, new Population(), null, initialization, variation);
 		this.divisions = divisions;
 	}
 
@@ -191,8 +209,7 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 			}
 		}
 		
-		// this call is likely not necessary, but is included in the Matlab
-		// version
+		// this call is likely not necessary, but is included in the Matlab version
 		preserveCorner();
 	}
 	
@@ -253,8 +270,7 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	}
 
 	/**
-	 * Returns the solution with the largest objective value for the given
-	 * objective.
+	 * Returns the solution with the largest objective value for the given objective.
 	 * 
 	 * @param objective the objective
 	 * @param population the population of solutions
@@ -275,8 +291,7 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	/**
-	 * Returns a copy of the population sorted by the objective value in
-	 * ascending order.
+	 * Returns a copy of the population sorted by the objective value in ascending order.
 	 * 
 	 * @param objective the objective
 	 * @param population the population
@@ -290,13 +305,11 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	/**
-	 * Returns a copy of the population sorted by the sum-of-squares of all
-	 * but one objective.
+	 * Returns a copy of the population sorted by the sum-of-squares of all but one objective.
 	 * 
 	 * @param objective the ignored objective
 	 * @param population the population
-	 * @return a copy of the population ordered by the sum-of-squares of all
-	 *         but one objective
+	 * @return a copy of the population ordered by the sum-of-squares of all but one objective
 	 */
 	private Population orderBySmallestSquaredValue(final int objective, Population population) {
 		Population result = new Population();
@@ -723,8 +736,7 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 		double[] objectiveValues = new double[problem.getNumberOfObjectives()];
 		
 		for (int j = 0; j < problem.getNumberOfObjectives(); j++) {
-			objectiveValues[j] = (solution.getObjective(j) - idealPoint[j]) /
-					(intercepts[j] - idealPoint[j]);
+			objectiveValues[j] = (solution.getObjective(j) - idealPoint[j]) / (intercepts[j] - idealPoint[j]);
 		}
 		
 		return objectiveValues;

--- a/src/org/moeaframework/algorithm/EpsilonMOEA.java
+++ b/src/org/moeaframework/algorithm/EpsilonMOEA.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.moeaframework.analysis.sensitivity.EpsilonHelper;
 import org.moeaframework.core.EpsilonBoxDominanceArchive;
 import org.moeaframework.core.EpsilonBoxEvolutionaryAlgorithm;
 import org.moeaframework.core.Initialization;
@@ -28,10 +29,14 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Selection;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.core.operator.TournamentSelection;
+import org.moeaframework.core.spi.OperatorFactory;
 
 /**
  * Implementation of the &epsilon;-MOEA algorithm.  The &epsilon;-MOEA is a
@@ -45,8 +50,7 @@ import org.moeaframework.core.comparator.ParetoDominanceComparator;
  *   Well-Spread Pareto-Optimal Solutions." KanGAL Report No 2003002. Feb 2003.
  * </ol>
  */
-public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements
-		EpsilonBoxEvolutionaryAlgorithm {
+public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements EpsilonBoxEvolutionaryAlgorithm {
 
 	/**
 	 * The dominance comparator used for updating the population.
@@ -57,27 +61,19 @@ public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements
 	 * The selection operator.
 	 */
 	private final Selection selection;
-
+	
 	/**
-	 * The variation operator.
-	 */
-	private final Variation variation;
-
-	/**
-	 * Constructs the &epsilon;-MOEA algorithm with the specified components.
+	 * Constructs the &epsilon;-MOEA algorithm with default settings.
 	 * 
-	 * @param problem the problem being solved
-	 * @param population the population used to store solutions
-	 * @param archive the archive used to store the result
-	 * @param selection the selection operator
-	 * @param variation the variation operator
-	 * @param initialization the initialization method
+	 * @param problem the problem
 	 */
-	public EpsilonMOEA(Problem problem, Population population,
-			EpsilonBoxDominanceArchive archive, Selection selection,
-			Variation variation, Initialization initialization) {
-		this(problem, population, archive, selection, variation,
-				initialization, new ParetoDominanceComparator());
+	public EpsilonMOEA(Problem problem) {
+		this(problem,
+				new Population(),
+				new EpsilonBoxDominanceArchive(EpsilonHelper.getEpsilon(problem)),
+				new TournamentSelection(2),
+				OperatorFactory.getInstance().getVariation(problem),
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE));
 	}
 
 	/**
@@ -89,15 +85,26 @@ public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements
 	 * @param selection the selection operator
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
-	 * @param dominanceComparator the dominance comparator used by the
-	 *        {@link #addToPopulation} method
 	 */
-	public EpsilonMOEA(Problem problem, Population population,
-			EpsilonBoxDominanceArchive archive, Selection selection,
-			Variation variation, Initialization initialization,
-			DominanceComparator dominanceComparator) {
-		super(problem, population, archive, initialization);
-		this.variation = variation;
+	public EpsilonMOEA(Problem problem, Population population, EpsilonBoxDominanceArchive archive, Selection selection,
+			Variation variation, Initialization initialization) {
+		this(problem, population, archive, selection, variation, initialization, new ParetoDominanceComparator());
+	}
+
+	/**
+	 * Constructs the &epsilon;-MOEA algorithm with the specified components.
+	 * 
+	 * @param problem the problem being solved
+	 * @param population the population used to store solutions
+	 * @param archive the archive used to store the result
+	 * @param selection the selection operator
+	 * @param variation the variation operator
+	 * @param initialization the initialization method
+	 * @param dominanceComparator the dominance comparator used by the {@link #addToPopulation} method
+	 */
+	public EpsilonMOEA(Problem problem, Population population, EpsilonBoxDominanceArchive archive, Selection selection,
+			Variation variation, Initialization initialization, DominanceComparator dominanceComparator) {
+		super(problem, population, archive, initialization, variation);
 		this.selection = selection;
 		this.dominanceComparator = dominanceComparator;
 	}
@@ -137,8 +144,7 @@ public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements
 		boolean dominated = false;
 
 		for (int i = 0; i < population.size(); i++) {
-			int flag = dominanceComparator.compare(newSolution, 
-			        population.get(i));
+			int flag = dominanceComparator.compare(newSolution, population.get(i));
 
 			if (flag < 0) {
 				dominates.add(i);

--- a/src/org/moeaframework/algorithm/GDE3.java
+++ b/src/org/moeaframework/algorithm/GDE3.java
@@ -21,10 +21,14 @@ import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedSortingPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.DominanceComparator;
-import org.moeaframework.core.operator.real.DifferentialEvolutionVariation;
+import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.real.DifferentialEvolutionSelection;
+import org.moeaframework.core.operator.real.DifferentialEvolutionVariation;
+import org.moeaframework.core.variable.RealVariable;
 
 /**
  * Implementation of the Generalized Differential Evolution (GDE3) algorithm.
@@ -47,11 +51,15 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 	 * The selection operator.
 	 */
 	private final DifferentialEvolutionSelection selection;
-
-	/**
-	 * The variation operator.
-	 */
-	private final DifferentialEvolutionVariation variation;
+	
+	public GDE3(Problem problem) {
+		this(problem,
+				new NondominatedSortingPopulation(),
+				new ParetoDominanceComparator(), // TODO: we should get this from NondominatedSortingPopulation
+				new DifferentialEvolutionSelection(),
+				new DifferentialEvolutionVariation(),
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE));
+	}
 
 	/**
 	 * Constructs the GDE3 algorithm with the specified components.
@@ -64,14 +72,14 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
 	 */
-	public GDE3(Problem problem, NondominatedSortingPopulation population,
-			DominanceComparator comparator,
-			DifferentialEvolutionSelection selection,
-			DifferentialEvolutionVariation variation, Initialization initialization) {
-		super(problem, population, null, initialization);
+	public GDE3(Problem problem, NondominatedSortingPopulation population, DominanceComparator comparator,
+			DifferentialEvolutionSelection selection, DifferentialEvolutionVariation variation,
+			Initialization initialization) {
+		super(problem, population, null, initialization, variation);
 		this.comparator = comparator;
 		this.selection = selection;
-		this.variation = variation;
+		
+		problem.assertType(RealVariable.class);
 	}
 
 	@Override
@@ -84,8 +92,7 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 		for (int i = 0; i < populationSize; i++) {
 			selection.setCurrentIndex(i);
 
-			Solution[] parents = selection.select(variation.getArity(),
-					population);
+			Solution[] parents = selection.select(variation.getArity(), population);
 			children.add(variation.evolve(parents)[0]);
 		}
 		
@@ -116,6 +123,11 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 	@Override
 	public NondominatedSortingPopulation getPopulation() {
 		return (NondominatedSortingPopulation)super.getPopulation();
+	}
+	
+	@Override
+	public DifferentialEvolutionVariation getVariation() {
+		return (DifferentialEvolutionVariation)super.getVariation();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/MOEAD.java
+++ b/src/org/moeaframework/algorithm/MOEAD.java
@@ -31,10 +31,14 @@ import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.operator.CompoundVariation;
+import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.real.DifferentialEvolutionVariation;
+import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.util.weights.RandomGenerator;
 import org.moeaframework.util.weights.WeightGenerator;
 
@@ -56,6 +60,473 @@ import org.moeaframework.util.weights.WeightGenerator;
  */
 public class MOEAD extends AbstractAlgorithm {
 
+	/**
+	 * The current population.
+	 */
+	private List<Individual> population;
+
+	/**
+	 * The ideal point; each index stores the best observed value for each objective.
+	 */
+	private double[] idealPoint;
+
+	/**
+	 * The size of the neighborhood used for mating.
+	 */
+	private final int neighborhoodSize;
+	
+	/**
+	 * The weight generator; or {@code null} if the default weight generator is used.
+	 */
+	private final WeightGenerator weightGenerator;
+
+	/**
+	 * The probability of mating with a solution in the neighborhood rather than the entire population.
+	 */
+	private final double delta;
+
+	/**
+	 * The maximum number of population slots a solution can replace.
+	 */
+	private final double eta;
+
+	/**
+	 * The initialization operator.
+	 */
+	private final Initialization initialization;
+
+	/**
+	 * The variation operator.
+	 */
+	private final Variation variation;
+
+	/**
+	 * The frequency, in generations, in which utility values are updated.  Set to {@code -1} to disable
+	 * utility-based search.  [2] recommends to update every {@code 50} generations.
+	 */
+	private final int updateUtility;
+
+	/**
+	 * Set to {@code true} if using differential evolution.
+	 */
+	final boolean useDE;
+	
+	/**
+	 * The current generation number.
+	 */
+	private int generation;
+	
+	/**
+	 * Constructs the MOEA/D algorithm with default settings.
+	 * 
+	 * @param problem the problem being solved
+	 */
+	public MOEAD(Problem problem) {
+		this(problem,
+				20, //neighborhoodSize
+				new RandomInitialization(problem, Math.max(Settings.DEFAULT_POPULATION_SIZE, problem.getNumberOfObjectives())),
+				OperatorFactory.getInstance().getVariation(problem.isType(RealVariable.class)? "de+pm": null, problem),
+				0.9, //delta
+				2, //eta
+				-1); //updateUtility
+	}
+	
+	/**
+	 * Constructs the MOEA/D algorithm with the specified components.  This
+	 * version of MOEA/D uses utility-based search as described in [2].
+	 * 
+	 * @param problem the problem being solved
+	 * @param neighborhoodSize the size of the neighborhood used for mating, which must be at least
+	 *        {@code variation.getArity()-1}.
+	 * @param initialization the initialization method
+	 * @param variation the variation operator
+	 * @param delta the probability of mating with a solution in the neighborhood rather than the entire population
+	 * @param eta the maximum number of population slots a solution can replace
+	 * @param updateUtility the frequency, in generations, in which utility values are updated; set to {@code 50} to
+	 *        use the recommended update frequency or {@code -1} to disable utility-based search.
+	 */
+	public MOEAD(Problem problem, int neighborhoodSize, Initialization initialization, Variation variation,
+			double delta, double eta, int updateUtility) {
+		this(problem, neighborhoodSize, null, initialization, variation, delta, eta, updateUtility);
+	}
+	
+	/**
+	 * Constructs the MOEA/D algorithm with the specified components.  This constructs the original MOEA/D
+	 * implementation without utility-based search.
+	 * 
+	 * @param problem the problem being solved
+	 * @param neighborhoodSize the size of the neighborhood used for mating, which must be at least
+	 *        {@code variation.getArity()-1}.
+	 * @param initialization the initialization method
+	 * @param variation the variation operator
+	 * @param delta the probability of mating with a solution in the neighborhood rather than the entire population
+	 * @param eta the maximum number of population slots a solution can replace
+	 */
+	public MOEAD(Problem problem, int neighborhoodSize, Initialization initialization, Variation variation,
+			double delta, double eta) {
+		this(problem, neighborhoodSize, initialization, variation, delta, eta, -1);
+	}
+
+	/**
+	 * Constructs the MOEA/D algorithm with the specified components.  This version of MOEA/D uses utility-based
+	 * search as described in [2].
+	 * 
+	 * @param problem the problem being solved
+	 * @param neighborhoodSize the size of the neighborhood used for mating, which must be at least
+	 *        {@code variation.getArity()-1}.
+	 * @param weightGenerator the weight generator
+	 * @param initialization the initialization method, which must generate the same number of solutions as weights
+	 * @param variation the variation operator
+	 * @param delta the probability of mating with a solution in the neighborhood rather than the entire population
+	 * @param eta the maximum number of population slots a solution can replace
+	 * @param updateUtility the frequency, in generations, in which utility values are updated; set to {@code 50} to
+	 *        use the recommended update frequency or {@code -1} to disable utility-based search.
+	 */
+	public MOEAD(Problem problem, int neighborhoodSize, WeightGenerator weightGenerator, Initialization initialization,
+			Variation variation, double delta, double eta, int updateUtility) {
+		super(problem);
+		this.neighborhoodSize = neighborhoodSize;
+		this.weightGenerator = weightGenerator;
+		this.initialization = initialization;
+		this.variation = variation;
+		this.delta = delta;
+		this.eta = eta;
+		this.updateUtility = updateUtility;
+		
+		if (variation instanceof DifferentialEvolutionVariation) {
+			useDE = true;
+		} else if (variation instanceof CompoundVariation) {
+			CompoundVariation compoundVariation = (CompoundVariation)variation;
+			useDE = compoundVariation.getName().startsWith(DifferentialEvolutionVariation.class.getSimpleName());
+		} else {
+			useDE = false;
+		}
+	}
+	
+	/**
+	 * Constructs the MOEA/D algorithm with the specified components.  By default, this constructs the original MOEA/D
+	 * implementation without utility-based search.
+	 * 
+	 * @param problem the problem being solved
+	 * @param neighborhoodSize the size of the neighborhood used for mating, which must be at least
+	 *        {@code variation.getArity()-1}.
+	 * @param weightGenerator the weight generator
+	 * @param initialization the initialization method, which must generate the same number of solutions as weights
+	 * @param variation the variation operator
+	 * @param delta the probability of mating with a solution in the neighborhood rather than the entire population
+	 * @param eta the maximum number of population slots a solution can replace
+	 */
+	public MOEAD(Problem problem, int neighborhoodSize, WeightGenerator weightGenerator, Initialization initialization,
+			Variation variation, double delta, double eta) {
+		this(problem, neighborhoodSize, weightGenerator, initialization, variation, delta, eta, -1);
+	}
+
+	@Override
+	public void initialize() {
+		super.initialize();
+
+		Solution[] initialSolutions = initialization.initialize();
+		
+		if (initialSolutions.length < problem.getNumberOfObjectives()) {
+			throw new FrameworkException("popultion size must be >= the number of objectives");
+		}
+
+		initializePopulation(initialSolutions.length);
+		initializeNeighborhoods();
+		initializeIdealPoint();
+		evaluateAll(initialSolutions);
+		
+		for (int i = 0; i < initialSolutions.length; i++) {
+			Solution solution = initialSolutions[i];
+			updateIdealPoint(solution);
+			population.get(i).setSolution(solution);
+		}
+
+		for (int i = 0; i < initialSolutions.length; i++) {
+			population.get(i).setFitness(fitness(population.get(i).getSolution(), population.get(i).getWeights()));
+		}
+	}
+
+	/**
+	 * Initializes the population using a procedure attempting to create a
+	 * uniform distribution of weights.
+	 * 
+	 * @param populationSize the population size
+	 */
+	private void initializePopulation(int populationSize) {
+		population = new ArrayList<Individual>(populationSize);
+		
+		if (weightGenerator == null) {
+			List<double[]> weights = new RandomGenerator(problem.getNumberOfObjectives(), populationSize).generate();
+			
+			for (double[] weight : weights) {
+				population.add(new Individual(weight));
+			}
+		} else {
+			List<double[]> weights = weightGenerator.generate();
+			
+			if (weights.size() != populationSize) {
+				throw new FrameworkException("weight generator must return " + populationSize + " weights");
+			}
+			
+			for (double[] weight : weights) {
+				population.add(new Individual(weight));
+			}
+		}
+	}
+
+	/**
+	 * Constructs the neighborhoods for all individuals in the population based
+	 * on the distances between weights.
+	 */
+	private void initializeNeighborhoods() {
+		List<Individual> sortedPopulation = new ArrayList<Individual>(
+				population);
+
+		for (Individual individual : population) {
+			Collections.sort(sortedPopulation, new WeightSorter(individual));
+
+			for (int i = 0; i < neighborhoodSize; i++) {
+				individual.addNeighbor(sortedPopulation.get(i));
+			}
+		}
+	}
+
+	/**
+	 * Initializes the ideal point.
+	 */
+	private void initializeIdealPoint() {
+		idealPoint = new double[problem.getNumberOfObjectives()];
+		Arrays.fill(idealPoint, Double.POSITIVE_INFINITY);
+	}
+
+	/**
+	 * Updates the ideal point with the specified solution.
+	 * 
+	 * @param solution the solution
+	 */
+	private void updateIdealPoint(Solution solution) {
+		for (int i = 0; i < solution.getNumberOfObjectives(); i++) {
+			idealPoint[i] = Math.min(idealPoint[i], solution.getObjective(i));
+		}
+	}
+
+	@Override
+	public NondominatedPopulation getResult() {
+		NondominatedPopulation result = new NondominatedPopulation();
+
+		if (population != null) {
+			for (Individual individual : population) {
+				result.add(individual.getSolution());
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns the population indices to be operated on in the current
+	 * generation.  If the utility update frequency has been set, then this
+	 * method follows the utility-based MOEA/D search described in [2].
+	 * Otherwise, this follows the original MOEA/D specification from [1].
+	 * 
+	 * @return the population indices to be operated on in the current generation
+	 */
+	private List<Integer> getSubproblemsToSearch() {
+		List<Integer> indices = new ArrayList<Integer>();
+		
+		if (updateUtility < 0) {
+			// return all indices
+			for (int i = 0; i < population.size(); i++) {
+				indices.add(i);
+			}
+		} else {
+			// return 1/5 of the indices chosen by their utility
+			for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
+				indices.add(i);
+			}
+	
+			for (int i = problem.getNumberOfObjectives(); i < population.size() / 5; i++) {
+				int index = PRNG.nextInt(population.size());
+	
+				for (int j = 1; j < 10; j++) {
+					int temp = PRNG.nextInt(population.size());
+					
+					if (population.get(temp).getUtility() > population.get(index).getUtility()) {
+						index = temp;
+					}
+				}
+	
+				indices.add(index);
+			}
+		}
+		
+		PRNG.shuffle(indices);
+
+		return indices;
+	}
+
+	/**
+	 * Returns the population indices to be considered during mating. With
+	 * probability {@code delta} the neighborhood is returned; otherwise, the
+	 * entire population is returned.
+	 * 
+	 * @param index the index of the first parent
+	 * @return the population indices to be considered during mating
+	 */
+	private List<Integer> getMatingIndices(int index) {
+		List<Integer> matingIndices = new ArrayList<Integer>();
+
+		if (PRNG.nextDouble() <= delta) {
+			for (Individual individual : population.get(index).getNeighbors()) {
+				matingIndices.add(population.indexOf(individual));
+			}
+		} else {
+			for (int i = 0; i < population.size(); i++) {
+				matingIndices.add(i);
+			}
+		}
+
+		return matingIndices;
+	}
+
+	/**
+	 * Evaluates the fitness of the specified solution using the Chebyshev weights.
+	 * 
+	 * @param solution the solution
+	 * @param weights the weights
+	 * @return the fitness of the specified solution using the Chebyshev weights
+	 */
+	private double fitness(Solution solution, double[] weights) {
+		double max = Double.NEGATIVE_INFINITY;
+
+		for (int i = 0; i < solution.getNumberOfObjectives(); i++) {
+			max = Math.max(max, Math.max(weights[i], 0.0001) * Math.abs(solution.getObjective(i) - idealPoint[i]));
+		}
+
+		if (solution.violatesConstraints()) {
+			max += 10000.0;
+		}
+
+		return max;
+	}
+	
+	private double sumOfConstraintViolations(Solution solution) {
+		double sum = 0.0;
+		
+		for (int i = 0; i < solution.getNumberOfConstraints(); i++) {
+			sum += Math.abs(solution.getConstraint(i));
+		}
+		
+		return sum;
+	}
+
+	/**
+	 * Updates the population with the specified solution. Only the specified
+	 * population indices are considered for updating. A maximum of {@code eta}
+	 * indices will be modified.
+	 * 
+	 * @param solution the solution
+	 * @param matingIndices the population indices that are available for updating
+	 */
+	private void updateSolution(Solution solution,
+			List<Integer> matingIndices) {
+		int c = 0;
+		PRNG.shuffle(matingIndices);
+		
+		for (int i = 0; i < matingIndices.size(); i++) {
+			Individual individual = population.get(matingIndices.get(i));
+			boolean canReplace = false;
+			
+			if (solution.violatesConstraints() && individual.getSolution().violatesConstraints()) {
+				double cv1 = sumOfConstraintViolations(solution);
+				double cv2 = sumOfConstraintViolations(individual.getSolution());
+				
+				if (cv1 < cv2) {
+					canReplace = true;
+				}
+			} else if (individual.getSolution().violatesConstraints()) {
+				canReplace = true;
+			} else if (solution.violatesConstraints()) {
+				// do nothing
+			} else {
+				if (fitness(solution, individual.getWeights()) < fitness(individual.getSolution(), individual.getWeights())) {
+					canReplace = true;
+				}
+			}
+			
+			if (canReplace) {
+				individual.setSolution(solution);
+				c = c + 1;
+			}
+			
+			if (c >= eta) {
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Updates the utility of each individual.
+	 */
+	protected void updateUtility() {
+		for (Individual individual : population) {
+			double oldFitness = individual.getFitness();
+			double newFitness = fitness(individual.getSolution(), idealPoint);
+			double relativeDecrease = (oldFitness - newFitness) / oldFitness; 
+
+			if (relativeDecrease > 0.001) {
+				individual.setUtility(1.0);
+			} else {
+				double utility = Math.min(1.0, (0.95 + 0.05*relativeDecrease/0.001)* individual.getUtility());
+				individual.setUtility(utility);
+			}
+
+			individual.setFitness(newFitness);
+		}
+	}
+
+	@Override
+	public void iterate() {
+		List<Integer> indices = getSubproblemsToSearch();
+
+		for (Integer index : indices) {
+			List<Integer> matingIndices = getMatingIndices(index);
+
+			Solution[] parents = new Solution[variation.getArity()];
+			parents[0] = population.get(index).getSolution();
+			
+			if (useDE) {
+				// MOEA/D parent selection for differential evolution
+				PRNG.shuffle(matingIndices);
+				
+				for (int i = 1; i < variation.getArity()-1; i++) {
+					parents[i] = population.get(matingIndices.get(i-1)).getSolution();
+				}
+				
+				parents[variation.getArity()-1] = population.get(index).getSolution();
+			} else {
+				for (int i = 1; i < variation.getArity(); i++) {
+					parents[i] = population.get(PRNG.nextItem(matingIndices)).getSolution();
+				}
+			}
+
+			Solution[] offspring = variation.evolve(parents);
+
+			for (Solution child : offspring) {
+				evaluate(child);
+				updateIdealPoint(child);
+				updateSolution(child, matingIndices);
+			}
+		}
+
+		generation++;
+
+		if ((updateUtility >= 0) && (generation % updateUtility == 0)) {
+			updateUtility();
+		}
+	}
+	
 	/**
 	 * Represents an individual (population slot) in the MOEA/D algorithm.
 	 */
@@ -202,8 +673,7 @@ public class MOEAD extends AbstractAlgorithm {
 		 * Constructs a comparator for comparing individuals based on their 
 		 * distance from the specified individual.
 		 * 
-		 * @param individual the individual from which weight distances are
-		 *        computed
+		 * @param individual the individual from which weight distances are computed
 		 */
 		public WeightSorter(Individual individual) {
 			this.individual = individual;
@@ -211,506 +681,16 @@ public class MOEAD extends AbstractAlgorithm {
 
 		@Override
 		public int compare(Individual o1, Individual o2) {
-			double d1 = MathArrays.distance(
-					individual.getWeights(), o1.getWeights());
-			double d2 = MathArrays.distance(
-					individual.getWeights(), o2.getWeights());
+			double d1 = MathArrays.distance(individual.getWeights(), o1.getWeights());
+			double d2 = MathArrays.distance(individual.getWeights(), o2.getWeights());
 
 			return Double.compare(d1, d2);
 		}
 
 	}
-
-	/**
-	 * The current population.
-	 */
-	private List<Individual> population;
-
-	/**
-	 * The ideal point; each index stores the best observed value for each
-	 * objective.
-	 */
-	private double[] idealPoint;
-
-	/**
-	 * The size of the neighborhood used for mating.
-	 */
-	private final int neighborhoodSize;
 	
 	/**
-	 * The weight generator; or {@code null} if the default weight generator
-	 * is used.
-	 */
-	private final WeightGenerator weightGenerator;
-
-	/**
-	 * The probability of mating with a solution in the neighborhood rather
-	 * than the entire population.
-	 */
-	private final double delta;
-
-	/**
-	 * The maximum number of population slots a solution can replace.
-	 */
-	private final double eta;
-
-	/**
-	 * The initialization operator.
-	 */
-	private final Initialization initialization;
-
-	/**
-	 * The variation operator.
-	 */
-	private final Variation variation;
-
-	/**
-	 * The frequency, in generations, in which utility values are updated.  Set
-	 * to {@code -1} to disable utility-based search.  [2] recommends to update
-	 * every {@code 50} generations.
-	 */
-	private final int updateUtility;
-
-	/**
-	 * Set to {@code true} if using differential evolution.
-	 */
-	final boolean useDE;
-	
-	/**
-	 * The current generation number.
-	 */
-	private int generation;
-	
-	/**
-	 * Constructs the MOEA/D algorithm with the specified components.  This
-	 * version of MOEA/D uses utility-based search as described in [2].
-	 * 
-	 * @param problem the problem being solved
-	 * @param neighborhoodSize the size of the neighborhood used for mating,
-	 *        which must be at least {@code variation.getArity()-1}.
-	 * @param initialization the initialization method
-	 * @param variation the variation operator
-	 * @param delta the probability of mating with a solution in the
-	 *        neighborhood rather than the entire population
-	 * @param eta the maximum number of population slots a solution can replace
-	 * @param updateUtility the frequency, in generations, in which utility
-	 *        values are updated; set to {@code 50} to use the recommended
-	 *        update frequency or {@code -1} to disable utility-based search.
-	 */
-	public MOEAD(Problem problem, int neighborhoodSize,
-			Initialization initialization, Variation variation, double delta,
-			double eta, int updateUtility) {
-		this(problem, neighborhoodSize, null, initialization, variation, delta,
-				eta, updateUtility);
-	}
-	
-	/**
-	 * Constructs the MOEA/D algorithm with the specified components.  This
-	 * constructs the original MOEA/D implementation without utility-based
-	 * search.
-	 * 
-	 * @param problem the problem being solved
-	 * @param neighborhoodSize the size of the neighborhood used for mating,
-	 *        which must be at least {@code variation.getArity()-1}.
-	 * @param initialization the initialization method
-	 * @param variation the variation operator
-	 * @param delta the probability of mating with a solution in the
-	 *        neighborhood rather than the entire population
-	 * @param eta the maximum number of population slots a solution can replace
-	 */
-	public MOEAD(Problem problem, int neighborhoodSize,
-			Initialization initialization, Variation variation, double delta,
-			double eta) {
-		this(problem, neighborhoodSize, initialization, variation, delta, eta,
-				-1);
-	}
-
-	/**
-	 * Constructs the MOEA/D algorithm with the specified components.  This
-	 * version of MOEA/D uses utility-based search as described in [2].
-	 * 
-	 * @param problem the problem being solved
-	 * @param neighborhoodSize the size of the neighborhood used for mating,
-	 *        which must be at least {@code variation.getArity()-1}.
-	 * @param weightGenerator the weight generator
-	 * @param initialization the initialization method, which must generate the
-	 *        same number of solutions as weights
-	 * @param variation the variation operator
-	 * @param delta the probability of mating with a solution in the
-	 *        neighborhood rather than the entire population
-	 * @param eta the maximum number of population slots a solution can replace
-	 * @param updateUtility the frequency, in generations, in which utility
-	 *        values are updated; set to {@code 50} to use the recommended
-	 *        update frequency or {@code -1} to disable utility-based search.
-	 */
-	public MOEAD(Problem problem, int neighborhoodSize,
-			WeightGenerator weightGenerator, Initialization initialization,
-			Variation variation, double delta, double eta, int updateUtility) {
-		super(problem);
-		this.neighborhoodSize = neighborhoodSize;
-		this.weightGenerator = weightGenerator;
-		this.initialization = initialization;
-		this.variation = variation;
-		this.delta = delta;
-		this.eta = eta;
-		this.updateUtility = updateUtility;
-		
-		if (variation instanceof DifferentialEvolutionVariation) {
-			useDE = true;
-		} else if (variation instanceof CompoundVariation) {
-			CompoundVariation compoundVariation = (CompoundVariation)variation;
-			useDE = compoundVariation.getName().startsWith(
-					DifferentialEvolutionVariation.class.getSimpleName());
-		} else {
-			useDE = false;
-		}
-	}
-	
-	/**
-	 * Constructs the MOEA/D algorithm with the specified components.  This
-	 * constructs the original MOEA/D implementation without utility-based
-	 * search.
-	 * 
-	 * @param problem the problem being solved
-	 * @param neighborhoodSize the size of the neighborhood used for mating,
-	 *        which must be at least {@code variation.getArity()-1}.
-	 * @param weightGenerator the weight generator
-	 * @param initialization the initialization method, which must generate the
-	 *        same number of solutions as weights
-	 * @param variation the variation operator
-	 * @param delta the probability of mating with a solution in the
-	 *        neighborhood rather than the entire population
-	 * @param eta the maximum number of population slots a solution can replace
-	 */
-	public MOEAD(Problem problem, int neighborhoodSize,
-			WeightGenerator weightGenerator, Initialization initialization,
-			Variation variation, double delta, double eta) {
-		this(problem, neighborhoodSize, weightGenerator, initialization,
-				variation, delta, eta, -1);
-	}
-
-	@Override
-	public void initialize() {
-		super.initialize();
-
-		Solution[] initialSolutions = initialization.initialize();
-
-		initializePopulation(initialSolutions.length);
-		initializeNeighborhoods();
-		initializeIdealPoint();
-		evaluateAll(initialSolutions);
-		
-		for (int i = 0; i < initialSolutions.length; i++) {
-			Solution solution = initialSolutions[i];
-			updateIdealPoint(solution);
-			population.get(i).setSolution(solution);
-		}
-
-		for (int i = 0; i < initialSolutions.length; i++) {
-			population.get(i).setFitness(fitness(
-					population.get(i).getSolution(),
-					population.get(i).getWeights()));
-		}
-	}
-
-	/**
-	 * Initializes the population using a procedure attempting to create a
-	 * uniform distribution of weights.
-	 * 
-	 * @param populationSize the population size
-	 */
-	private void initializePopulation(int populationSize) {
-		population = new ArrayList<Individual>(populationSize);
-		
-		if (weightGenerator == null) {
-			List<double[]> weights = new RandomGenerator(
-					problem.getNumberOfObjectives(), populationSize).generate();
-			
-			for (double[] weight : weights) {
-				population.add(new Individual(weight));
-			}
-		} else {
-			List<double[]> weights = weightGenerator.generate();
-			
-			if (weights.size() != populationSize) {
-				throw new FrameworkException("weight generator must return " +
-						populationSize + " weights");
-			}
-			
-			for (double[] weight : weights) {
-				population.add(new Individual(weight));
-			}
-		}
-	}
-
-	/**
-	 * Constructs the neighborhoods for all individuals in the population based
-	 * on the distances between weights.
-	 */
-	private void initializeNeighborhoods() {
-		List<Individual> sortedPopulation = new ArrayList<Individual>(
-				population);
-
-		for (Individual individual : population) {
-			Collections.sort(sortedPopulation, new WeightSorter(individual));
-
-			for (int i = 0; i < neighborhoodSize; i++) {
-				individual.addNeighbor(sortedPopulation.get(i));
-			}
-		}
-	}
-
-	/**
-	 * Initializes the ideal point.
-	 */
-	private void initializeIdealPoint() {
-		idealPoint = new double[problem.getNumberOfObjectives()];
-		Arrays.fill(idealPoint, Double.POSITIVE_INFINITY);
-	}
-
-	/**
-	 * Updates the ideal point with the specified solution.
-	 * 
-	 * @param solution the solution
-	 */
-	private void updateIdealPoint(Solution solution) {
-		for (int i = 0; i < solution.getNumberOfObjectives(); i++) {
-			idealPoint[i] = Math.min(idealPoint[i], solution.getObjective(i));
-		}
-	}
-
-	@Override
-	public NondominatedPopulation getResult() {
-		NondominatedPopulation result = new NondominatedPopulation();
-
-		if (population != null) {
-			for (Individual individual : population) {
-				result.add(individual.getSolution());
-			}
-		}
-
-		return result;
-	}
-
-	/**
-	 * Returns the population indices to be operated on in the current
-	 * generation.  If the utility update frequency has been set, then this
-	 * method follows the utility-based MOEA/D search described in [2].
-	 * Otherwise, this follows the original MOEA/D specification from [1].
-	 * 
-	 * @return the population indices to be operated on in the current
-	 *         generation
-	 */
-	private List<Integer> getSubproblemsToSearch() {
-		List<Integer> indices = new ArrayList<Integer>();
-		
-		if (updateUtility < 0) {
-			// return all indices
-			for (int i = 0; i < population.size(); i++) {
-				indices.add(i);
-			}
-		} else {
-			// return 1/5 of the indices chosen by their utility
-			for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-				indices.add(i);
-			}
-	
-			for (int i = problem.getNumberOfObjectives(); i < population.size() / 5; i++) {
-				int index = PRNG.nextInt(population.size());
-	
-				for (int j = 1; j < 10; j++) {
-					int temp = PRNG.nextInt(population.size());
-					
-					if (population.get(temp).getUtility() > 
-							population.get(index).getUtility()) {
-						index = temp;
-					}
-				}
-	
-				indices.add(index);
-			}
-		}
-		
-		PRNG.shuffle(indices);
-
-		return indices;
-	}
-
-	/**
-	 * Returns the population indices to be considered during mating. With
-	 * probability {@code delta} the neighborhood is returned; otherwise, the
-	 * entire population is returned.
-	 * 
-	 * @param index the index of the first parent
-	 * @return the population indices to be considered during mating
-	 */
-	private List<Integer> getMatingIndices(int index) {
-		List<Integer> matingIndices = new ArrayList<Integer>();
-
-		if (PRNG.nextDouble() <= delta) {
-			for (Individual individual : population.get(index).getNeighbors()) {
-				matingIndices.add(population.indexOf(individual));
-			}
-		} else {
-			for (int i = 0; i < population.size(); i++) {
-				matingIndices.add(i);
-			}
-		}
-
-		return matingIndices;
-	}
-
-	/**
-	 * Evaluates the fitness of the specified solution using the Chebyshev
-	 * weights.
-	 * 
-	 * @param solution the solution
-	 * @param weights the weights
-	 * @return the fitness of the specified solution using the Chebyshev
-	 *         weights
-	 */
-	private double fitness(Solution solution, double[] weights) {
-		double max = Double.NEGATIVE_INFINITY;
-
-		for (int i = 0; i < solution.getNumberOfObjectives(); i++) {
-			max = Math.max(max, Math.max(weights[i], 0.0001)
-					* Math.abs(solution.getObjective(i) - idealPoint[i]));
-		}
-
-		if (solution.violatesConstraints()) {
-			max += 10000.0;
-		}
-
-		return max;
-	}
-	
-	private double sumOfConstraintViolations(Solution solution) {
-		double sum = 0.0;
-		
-		for (int i = 0; i < solution.getNumberOfConstraints(); i++) {
-			sum += Math.abs(solution.getConstraint(i));
-		}
-		
-		return sum;
-	}
-
-	/**
-	 * Updates the population with the specified solution. Only the specified
-	 * population indices are considered for updating. A maximum of {@code eta}
-	 * indices will be modified.
-	 * 
-	 * @param solution the solution
-	 * @param matingIndices the population indices that are available for
-	 *        updating
-	 */
-	private void updateSolution(Solution solution,
-			List<Integer> matingIndices) {
-		int c = 0;
-		PRNG.shuffle(matingIndices);
-		
-		for (int i = 0; i < matingIndices.size(); i++) {
-			Individual individual = population.get(matingIndices.get(i));
-			boolean canReplace = false;
-			
-			if (solution.violatesConstraints() &&
-					individual.getSolution().violatesConstraints()) {
-				double cv1 = sumOfConstraintViolations(solution);
-				double cv2 = sumOfConstraintViolations(individual.getSolution());
-				
-				if (cv1 < cv2) {
-					canReplace = true;
-				}
-			} else if (individual.getSolution().violatesConstraints()) {
-				canReplace = true;
-			} else if (solution.violatesConstraints()) {
-				// do nothing
-			} else {
-				if (fitness(solution, individual.getWeights()) <
-						fitness(individual.getSolution(),
-								individual.getWeights())) {
-					canReplace = true;
-				}
-			}
-			
-			if (canReplace) {
-				individual.setSolution(solution);
-				c = c + 1;
-			}
-			
-			if (c >= eta) {
-				break;
-			}
-		}
-	}
-
-	/**
-	 * Updates the utility of each individual.
-	 */
-	protected void updateUtility() {
-		for (Individual individual : population) {
-			double oldFitness = individual.getFitness();
-			double newFitness = fitness(individual.getSolution(), idealPoint);
-			double relativeDecrease = (oldFitness - newFitness) / oldFitness; 
-
-			if (relativeDecrease > 0.001) {
-				individual.setUtility(1.0);
-			} else {
-				double utility = Math.min(1.0,
-						(0.95 + 0.05*relativeDecrease/0.001)* individual.getUtility());
-				individual.setUtility(utility);
-			}
-
-			individual.setFitness(newFitness);
-		}
-	}
-
-	@Override
-	public void iterate() {
-		List<Integer> indices = getSubproblemsToSearch();
-
-		for (Integer index : indices) {
-			List<Integer> matingIndices = getMatingIndices(index);
-
-			Solution[] parents = new Solution[variation.getArity()];
-			parents[0] = population.get(index).getSolution();
-			
-			if (useDE) {
-				// MOEA/D parent selection for differential evolution
-				PRNG.shuffle(matingIndices);
-				
-				for (int i = 1; i < variation.getArity()-1; i++) {
-					parents[i] = population.get(
-							matingIndices.get(i-1)).getSolution();
-				}
-				
-				parents[variation.getArity()-1] = 
-						population.get(index).getSolution();
-			} else {
-				for (int i = 1; i < variation.getArity(); i++) {
-					parents[i] = population.get(
-							PRNG.nextItem(matingIndices)).getSolution();
-				}
-			}
-
-			Solution[] offspring = variation.evolve(parents);
-
-			for (Solution child : offspring) {
-				evaluate(child);
-				updateIdealPoint(child);
-				updateSolution(child, matingIndices);
-			}
-		}
-
-		generation++;
-
-		if ((updateUtility >= 0) && (generation % updateUtility == 0)) {
-			updateUtility();
-		}
-	}
-	
-	/**
-	 * Proxy for serializing and deserializing the state of a
-	 * {@code MOEAD} instance. This proxy supports saving
+	 * Proxy for serializing and deserializing the state of a {@code MOEAD} instance. This proxy supports saving
 	 * the {@code population}, {@code idealPoint} and {@code generation}.
 	 */
 	private static class MOEADState implements Serializable {
@@ -739,17 +719,12 @@ public class MOEAD extends AbstractAlgorithm {
 		private final int generation;
 		
 		/**
-		 * Constructs a proxy for serializing and deserializing the state of a
-		 * {@code MOEAD} instance.
+		 * Constructs a proxy for serializing and deserializing the state of a {@code MOEAD} instance.
 		 * 
-		 * @param population the {@code population} from the {@code MOEAD}
-		 *        instance
-		 * @param idealPoint the value of the {@code idealPoint} from the
-		 *        {@code MOEAD} instance
-		 * @param numberOfEvaluations the value of {@code numberOfEvaluations}
-		 *        from the {@code MOEAD} instance
-		 * @param generation the value of {@code generation} from the
-		 *        {@code MOEAD} instance
+		 * @param population the {@code population} from the {@code MOEAD} instance
+		 * @param idealPoint the value of the {@code idealPoint} from the {@code MOEAD} instance
+		 * @param numberOfEvaluations the value of {@code numberOfEvaluations} from the {@code MOEAD} instance
+		 * @param generation the value of {@code generation} from the {@code MOEAD} instance
 		 */
 		public MOEADState(List<Individual> population, double[] idealPoint,
 				int numberOfEvaluations, int generation) {
@@ -806,8 +781,7 @@ public class MOEAD extends AbstractAlgorithm {
 
 	@Override
 	public Serializable getState() throws NotSerializableException {
-		return new MOEADState(population, idealPoint, numberOfEvaluations,
-				generation);
+		return new MOEADState(population, idealPoint, numberOfEvaluations, generation);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/PESA2.java
+++ b/src/org/moeaframework/algorithm/PESA2.java
@@ -32,8 +32,11 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Selection;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.core.spi.OperatorFactory;
 
 /**
  * Implementation of the Pareto Envelope-based Selection Algorithm (PESA2).
@@ -55,17 +58,25 @@ public class PESA2 extends AbstractEvolutionaryAlgorithm {
 	 * The selection operator.
 	 */
 	protected final Selection selection;
-
-	/**
-	 * The variation operator.
-	 */
-	protected final Variation variation;
 	
 	/**
 	 * A mapping from grid index to the solutions occupying that grid index.
 	 * This enables PESA2's region-based selection.
 	 */
 	protected Map<Integer, List<Solution>> gridMap;
+	
+	/**
+	 * Constructs a new PESA2 instance with default settings.
+	 * 
+	 * @param problem the problem
+	 */
+	public PESA2(Problem problem) {
+		this(problem,
+				OperatorFactory.getInstance().getVariation(problem),
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				8,
+				100);
+	}
 
 	/**
 	 * Constructs a new PESA2 instance.
@@ -82,8 +93,8 @@ public class PESA2 extends AbstractEvolutionaryAlgorithm {
 				new Population(),
 				new AdaptiveGridArchive(archiveSize, problem,
 						ArithmeticUtils.pow(2, bisections)),
-				initialization);
-		this.variation = variation;
+				initialization,
+				variation);
 		
 		selection = new RegionBasedSelection();
 	}

--- a/src/org/moeaframework/algorithm/RVEA.java
+++ b/src/org/moeaframework/algorithm/RVEA.java
@@ -30,6 +30,9 @@ import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.weights.NormalBoundaryDivisions;
 
 /**
  * Implementation of the Reference Vector Guided Evolutionary Algorithm (RVEA).
@@ -52,11 +55,6 @@ import org.moeaframework.core.Variation;
 public class RVEA extends AbstractEvolutionaryAlgorithm {
 	
 	/**
-	 * The variation operator.
-	 */
-	private final Variation variation;
-	
-	/**
 	 * The current generation;
 	 */
 	private int generation;
@@ -65,12 +63,40 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	 * The maximum number of generations for the angle-penalized distance to
 	 * transition between convergence and diversity.
 	 */
-	private int maxGeneration = 1000;
+	private final int maxGeneration;
 	
 	/**
 	 * The frequency, in generations, that the reference vectors are normalized.
 	 */
-	private int adaptFrequency = maxGeneration / 10;
+	private final int adaptFrequency;
+	
+	/**
+	 * Constructs a new instance of RVEA with default settings.
+	 * 
+	 * @param problem the problem being solved
+	 * @param maxGeneration the maximum number of generations for the angle-penalized distance to transition
+	 *        between convergence and diversity
+	 */
+	public RVEA(Problem problem, int maxGeneration) {
+		this(problem, NormalBoundaryDivisions.forProblem(problem), maxGeneration);
+	}
+	
+	/**
+	 * Constructs a new instance of RVEA with default settings.
+	 * 
+	 * @param problem the problem being solved
+	 * @param divisions the number of divisions used by the reference vector guided population
+	 * @param maxGeneration the maximum number of generations for the angle-penalized distance to transition
+	 *        between convergence and diversity
+	 */
+	public RVEA(Problem problem, NormalBoundaryDivisions divisions, int maxGeneration) {
+		this(problem,
+				new ReferenceVectorGuidedPopulation(problem.getNumberOfObjectives(), divisions),
+				OperatorFactory.getInstance().getVariation(problem),
+				new RandomInitialization(problem, divisions.getNumberOfReferencePoints(problem)),
+				maxGeneration,
+				maxGeneration / 10);
+	}
 
 	/**
 	 * Constructs a new instance of the RVEA algorithm.
@@ -79,22 +105,23 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	 * @param population the population used to store solutions
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
-	 * @param maxGeneration the maximum number of generations for the
-	 *        angle-penalized distance to transition between convergence and
-	 *        diversity
-	 * @param adaptFrequency the frequency, in generations, that the reference
-	 *        vectors are normalized.
+	 * @param maxGeneration the maximum number of generations for the angle-penalized distance to transition
+	 *        between convergence and diversity
+	 * @param adaptFrequency the frequency, in generations, that the reference vectors are normalized
 	 */
-	public RVEA(Problem problem, ReferenceVectorGuidedPopulation population,
-			Variation variation, Initialization initialization,
-			int maxGeneration, int adaptFrequency) {
-		super(problem, population, null, initialization);
-		this.variation = variation;
+	public RVEA(Problem problem, ReferenceVectorGuidedPopulation population, Variation variation,
+			Initialization initialization, int maxGeneration, int adaptFrequency) {
+		super(problem, population, null, initialization, variation);
+		this.maxGeneration = maxGeneration;
+		this.adaptFrequency = adaptFrequency;
 		
 		// catch potential errors
 		if (variation.getArity() != 2) {
-			throw new FrameworkException(
-					"RVEA only supports operators requiring 2 parents");
+			throw new FrameworkException("RVEA only supports operators requiring 2 parents");
+		}
+		
+		if (problem.getNumberOfObjectives() < 2) {
+			throw new FrameworkException("RVEA requires at least two objectives");
 		}
 	}
 
@@ -105,8 +132,7 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 		int populationSize = population.size();
 		
 		// update the scaling factor for computing the angle-penalized distance
-		population.setScalingFactor(Math.min(generation / (double)maxGeneration,
-				1.0));
+		population.setScalingFactor(Math.min(generation / (double)maxGeneration, 1.0));
 		
 		// create a random permutation of the population indices
 		List<Integer> indices = new ArrayList<Integer>();
@@ -152,12 +178,10 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	@Override
 	public Serializable getState() throws NotSerializableException {
 		if (!isInitialized()) {
-			throw new AlgorithmInitializationException(this, 
-					"algorithm not initialized");
+			throw new AlgorithmInitializationException(this, "algorithm not initialized");
 		}
 
-		return new RVEAState(getNumberOfEvaluations(), generation,
-				getPopulation().getState());
+		return new RVEAState(getNumberOfEvaluations(), generation, getPopulation().getState());
 	}
 
 	@Override
@@ -199,13 +223,11 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 		 * Constructs a proxy to serialize and deserialize the state of an 
 		 * {@code RVEA} instance.
 		 * 
-		 * @param numberOfEvaluations the number of objective function
-		 *        evaluations
+		 * @param numberOfEvaluations the number of objective function evaluations
 		 * @param generation the current generation
 		 * @param population the population stored in a serializable object
 		 */
-		public RVEAState(int numberOfEvaluations, int generation,
-				ReferenceVectorGuidedPopulationState populationState) {
+		public RVEAState(int numberOfEvaluations, int generation, ReferenceVectorGuidedPopulationState populationState) {
 			super();
 			this.numberOfEvaluations = numberOfEvaluations;
 			this.generation = generation;

--- a/src/org/moeaframework/algorithm/RandomSearch.java
+++ b/src/org/moeaframework/algorithm/RandomSearch.java
@@ -21,6 +21,8 @@ import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
+import org.moeaframework.core.operator.RandomInitialization;
 
 /**
  * Random search implementation.  An {@link Initialization} instance is used
@@ -38,17 +40,26 @@ public class RandomSearch extends AbstractAlgorithm {
 	 * The archive of non-dominated solutions.
 	 */
 	private final NondominatedPopulation archive;
+	
+	/**
+	 * Constructs a new random search procedure with default settings.
+	 * 
+	 * @param problem the problem being solved
+	 */
+	public RandomSearch(Problem problem) {
+		this(problem,
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new NondominatedPopulation());
+	}
 
 	/**
 	 * Constructs a new random search procedure for the given problem.
 	 * 
 	 * @param problem the problem being solved
-	 * @param generator the initialization routine used to generate random
-	 *        solutions
+	 * @param generator the initialization routine used to generate random solutions
 	 * @param archive the archive of non-dominated solutions
 	 */
-	public RandomSearch(Problem problem, Initialization generator,
-			NondominatedPopulation archive) {
+	public RandomSearch(Problem problem, Initialization generator, NondominatedPopulation archive) {
 		super(problem);
 		this.generator = generator;
 		this.archive = archive;

--- a/src/org/moeaframework/algorithm/ReferenceVectorGuidedPopulation.java
+++ b/src/org/moeaframework/algorithm/ReferenceVectorGuidedPopulation.java
@@ -90,6 +90,16 @@ public class ReferenceVectorGuidedPopulation extends Population {
 	private final double alpha;
 	
 	/**
+	 * Constructs a new populationf or RVEA using default settings.
+	 * 
+	 * @param numberOfObjectives the number of objectives
+	 * @param divisions the number of divisions
+	 */
+	public ReferenceVectorGuidedPopulation(int numberOfObjectives, NormalBoundaryDivisions divisions) {
+		this(numberOfObjectives, divisions, 2.0);
+	}
+	
+	/**
 	 * Constructs a new population for RVEA.
 	 * 
 	 * @param numberOfObjectives the number of objectives
@@ -332,8 +342,7 @@ public class ReferenceVectorGuidedPopulation extends Population {
 		
 		for (int i = 0; i < weights.size(); i++) {
 			if (i != index) {
-				smallestAngle = Math.min(smallestAngle,
-						acosine(weights.get(index), weights.get(i)));
+				smallestAngle = Math.min(smallestAngle, acosine(weights.get(index), weights.get(i)));
 			}
 		}
 		
@@ -354,8 +363,7 @@ public class ReferenceVectorGuidedPopulation extends Population {
 		
 		for (Solution solution : solutions) {
 			if (!solution.violatesConstraints()) {
-				double[] objectives = (double[])solution.getAttribute(
-						NORMALIZED_OBJECTIVES);
+				double[] objectives = (double[])solution.getAttribute(NORMALIZED_OBJECTIVES);
 				
 				double penalty = numberOfObjectives *
 						Math.pow(scalingFactor, alpha) *

--- a/src/org/moeaframework/algorithm/SPEA2.java
+++ b/src/org/moeaframework/algorithm/SPEA2.java
@@ -31,13 +31,16 @@ import org.moeaframework.core.Initialization;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Selection;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.FitnessComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
 import org.moeaframework.core.indicator.IndicatorUtils;
+import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.TournamentSelection;
+import org.moeaframework.core.spi.OperatorFactory;
 
 /**
  * Implementation of the strength-based evolutionary algorithm (SPEA2).  SPEA2
@@ -69,11 +72,6 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	private final Selection selection;
 	
 	/**
-	 * The variation operator.
-	 */
-	private final Variation variation;
-	
-	/**
 	 * The number of offspring.
 	 */
 	private final int numberOfOffspring;
@@ -87,6 +85,19 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	 * Compares solutions based on strength.
 	 */
 	protected final FitnessComparator fitnessComparator;
+	
+	/**
+	 * Constructs a new instance of SPEA2 with default settings.
+	 * 
+	 * @param problem the problem
+	 */
+	public SPEA2(Problem problem) {
+		this(problem,
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				OperatorFactory.getInstance().getVariation(problem),
+				Settings.DEFAULT_POPULATION_SIZE,
+				1);
+	}
 
 	/**
 	 * Constructs a new instance of SPEA2.
@@ -100,8 +111,7 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	 */
 	public SPEA2(Problem problem, Initialization initialization,
 			Variation variation, int numberOfOffspring, int k) {
-		super(problem, new Population(), null, initialization);
-		this.variation = variation;
+		super(problem, new Population(), null, initialization, variation);
 		this.numberOfOffspring = numberOfOffspring;
 		
 		fitnessEvaluator = new StrengthFitnessEvaluator(k);

--- a/src/org/moeaframework/algorithm/VEGA.java
+++ b/src/org/moeaframework/algorithm/VEGA.java
@@ -23,10 +23,13 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Selection;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.ObjectiveComparator;
+import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.TournamentSelection;
+import org.moeaframework.core.spi.OperatorFactory;
 
 /**
  * Implementation of the Vector Evaluated Genetic Algorithm (VEGA).  VEGA should
@@ -57,26 +60,31 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 	private Selection selection;
 	
 	/**
-	 * The variation operator.
+	 * Constructs a new VEGA instance with default settings.
+	 * 
+	 * @param problem the problem
 	 */
-	private Variation variation;
+	public VEGA(Problem problem) {
+		this(problem,
+				new Population(),
+				null,
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				OperatorFactory.getInstance().getVariation(problem));
+	}
 
 	/**
 	 * Constructs a new VEGA instance.
 	 * 
 	 * @param problem the problem
 	 * @param population the population
-	 * @param archive the external archive; or {@code null} if no external
-	 *        archive is used
+	 * @param archive the external archive; or {@code null} if no external archive is used
 	 * @param initialization the initialization operator
 	 * @param variation the variation operator
 	 */
 	public VEGA(Problem problem, Population population,
 			NondominatedPopulation archive, Initialization initialization,
 			Variation variation) {
-		super(problem, population, archive, initialization);
-		this.variation = variation;
-		
+		super(problem, population, archive, initialization, variation);		
 		selection = new VEGASelection();
 	}
 
@@ -97,8 +105,7 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 		population.clear();
 		
 		while (!filled) {
-			Solution[] offspring = variation.evolve(
-					select(parents, index, variation.getArity()));
+			Solution[] offspring = variation.evolve(select(parents, index, variation.getArity()));
 			
 			for (int i = 0; i < offspring.length; i++) {
 				population.add(offspring[i]);
@@ -135,8 +142,7 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 	}
 
 	/**
-	 * VEGA selection operator that selects parents based on only one of the
-	 * objectives.  
+	 * VEGA selection operator that selects parents based on only one of the objectives.  
 	 */
 	private class VEGASelection implements Selection {
 		
@@ -148,8 +154,7 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 			selectors = new Selection[problem.getNumberOfObjectives()];
 			
 			for (int i = 0; i < problem.getNumberOfObjectives(); i++) {
-				selectors[i] = new TournamentSelection(
-						new ObjectiveComparator(i));
+				selectors[i] = new TournamentSelection(new ObjectiveComparator(i));
 			}
 		}
 

--- a/src/org/moeaframework/algorithm/pso/OMOPSO.java
+++ b/src/org/moeaframework/algorithm/pso/OMOPSO.java
@@ -17,15 +17,17 @@
  */
 package org.moeaframework.algorithm.pso;
 
+import org.moeaframework.analysis.sensitivity.EpsilonHelper;
 import org.moeaframework.core.EpsilonBoxDominanceArchive;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Problem;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.comparator.CrowdingComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
 import org.moeaframework.core.fitness.CrowdingDistanceFitnessEvaluator;
 import org.moeaframework.core.fitness.FitnessBasedArchive;
+import org.moeaframework.core.operator.AbstractMutation;
+import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.RealVariable;
 
 // NOTE: This implementation is derived from the original manuscripts and the
@@ -52,12 +54,29 @@ public class OMOPSO extends AbstractPSOAlgorithm {
 	/**
 	 * The uniform mutation operator, whose parameters remain unchanged.
 	 */
-	private final Variation uniformMutation;
+	private final Mutation uniformMutation;
 	
 	/**
 	 * The non-uniform mutation operator, whose parameters change during a run.
 	 */
-	private final Variation nonUniformMutation;
+	private final Mutation nonUniformMutation;
+	
+	/**
+	 * Constructs a new OMOPSO instance with default settings.
+	 * 
+	 * @param problem the problem
+	 * @param maxIterations the maximum number of iterations for scaling non-uniform mutation;
+	 *        typically this should be {@code maxEvaluations / swarmSize}
+	 */
+	public OMOPSO(Problem problem, int maxIterations) {
+		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
+				Settings.DEFAULT_POPULATION_SIZE,
+				new double[] { EpsilonHelper.getEpsilon(problem) },
+				1.0 / problem.getNumberOfVariables(),
+				0.5,
+				maxIterations);
+	}
 	
 	/**
 	 * Constructs a new OMOPSO instance.
@@ -82,67 +101,51 @@ public class OMOPSO extends AbstractPSOAlgorithm {
 		
 		this.uniformMutation = new UniformMutation(mutationProbability, mutationPerturbation);
 		this.nonUniformMutation = new NonUniformMutation(mutationProbability, mutationPerturbation, maxIterations);
+		
+		problem.assertType(RealVariable.class);
 	}
 	
 	@Override
 	protected void mutate(int i) {
 		if (i % 3 == 0) {
-			particles[i] = nonUniformMutation.evolve(new Solution[] { particles[i] })[0];
+			particles[i] = nonUniformMutation.mutate(particles[i]);
 		} else if (i % 3 == 1) {
-			particles[i] = uniformMutation.evolve(new Solution[] { particles[i] })[0];
+			particles[i] = uniformMutation.mutate(particles[i]);
 		}
 	}
 	
 	/**
 	 * The non-uniform mutation operator.
 	 */
-	private class NonUniformMutation implements Variation {
-		
-		private final double probability;
+	private class NonUniformMutation extends AbstractMutation<RealVariable> {
 		
 		private final double perturbation;
 		
 		private final int maxIterations;
 		
-		public NonUniformMutation(double probability, double perturbation,
-				int maxIterations) {
-			super();
-			this.probability = probability;
+		public NonUniformMutation(double probability, double perturbation, int maxIterations) {
+			super(RealVariable.class, probability);
 			this.perturbation = perturbation;
 			this.maxIterations = maxIterations;
 		}
-
+		
 		@Override
-		public int getArity() {
-			return 1;
-		}
-
-		@Override
-		public Solution[] evolve(Solution[] parents) {
-			Solution offspring = parents[0].copy();
-			
-			for (int i = 0; i < offspring.getNumberOfVariables(); i++) {
-				if (PRNG.nextDouble() < probability) {
-					RealVariable variable = (RealVariable)offspring.getVariable(i);
-					double value = variable.getValue();
-					
-					if (PRNG.nextBoolean()) {
-						value += getDelta(variable.getUpperBound() - value);
-					} else {
-						value += getDelta(variable.getLowerBound() - value);
-					}
-
-					if (value < variable.getLowerBound()) {
-						value = variable.getLowerBound();
-					} else if (value > variable.getUpperBound()) {
-						value = variable.getUpperBound();
-					}
-					
-					variable.setValue(value);
-				}
+		public void mutate(RealVariable variable) {
+			double value = variable.getValue();
+				
+			if (PRNG.nextBoolean()) {
+				value += getDelta(variable.getUpperBound() - value);
+			} else {
+				value += getDelta(variable.getLowerBound() - value);
 			}
-			
-			return new Solution[] { offspring };
+
+			if (value < variable.getLowerBound()) {
+				value = variable.getLowerBound();
+			} else if (value > variable.getUpperBound()) {
+				value = variable.getUpperBound();
+			}
+					
+			variable.setValue(value);
 		}
 		
 		public double getDelta(double difference) {
@@ -157,45 +160,28 @@ public class OMOPSO extends AbstractPSOAlgorithm {
 	/**
 	 * The uniform mutation operator.
 	 */
-	private class UniformMutation implements Variation {
-		
-		private final double probability;
+	private class UniformMutation extends AbstractMutation<RealVariable> {
 		
 		private final double perturbation;
 		
 		public UniformMutation(double probability, double perturbation) {
-			super();
-			this.probability = probability;
+			super(RealVariable.class, probability);
 			this.perturbation = perturbation;
 		}
 
 		@Override
-		public int getArity() {
-			return 1;
-		}
-
-		@Override
-		public Solution[] evolve(Solution[] parents) {
-			Solution offspring = parents[0].copy();
-			
-			for (int i = 0; i < offspring.getNumberOfVariables(); i++) {
-				if (PRNG.nextDouble() < probability) {
-					RealVariable variable = (RealVariable)offspring.getVariable(i);
-					double value = variable.getValue();
+		public void mutate(RealVariable variable) {
+			double value = variable.getValue();
 					
-					value += (PRNG.nextDouble() - 0.5) * perturbation;
+			value += (PRNG.nextDouble() - 0.5) * perturbation;
 					
-					if (value < variable.getLowerBound()) {
-						value = variable.getLowerBound();
-					} else if (value > variable.getUpperBound()) {
-						value = variable.getUpperBound();
-					}
-					
-					variable.setValue(value);
-				}
+			if (value < variable.getLowerBound()) {
+				value = variable.getLowerBound();
+			} else if (value > variable.getUpperBound()) {
+				value = variable.getUpperBound();
 			}
-			
-			return new Solution[] { offspring };
+					
+			variable.setValue(value);
 		}
 		
 	}

--- a/src/org/moeaframework/algorithm/pso/SMPSO.java
+++ b/src/org/moeaframework/algorithm/pso/SMPSO.java
@@ -19,6 +19,7 @@ package org.moeaframework.algorithm.pso;
 
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.CrowdingComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
@@ -60,6 +61,19 @@ public class SMPSO extends AbstractPSOAlgorithm {
 	private double[] maximumVelocity;
 	
 	/**
+	 * Constructs a new SMPSO instance with default settings.
+	 * 
+	 * @param problem the problem
+	 */
+	public SMPSO(Problem problem) {
+		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
+				Settings.DEFAULT_POPULATION_SIZE,
+				1.0 / problem.getNumberOfVariables(),
+				20.0);
+	}
+	
+	/**
 	 * Constructs a new SMPSO instance.
 	 * 
 	 * @param problem the problem
@@ -76,6 +90,8 @@ public class SMPSO extends AbstractPSOAlgorithm {
 				new FitnessBasedArchive(new CrowdingDistanceFitnessEvaluator(), leaderSize),
 				null,
 				new PM(mutationProbability, distributionIndex));
+		
+		problem.assertType(RealVariable.class);
 
 		// initialize the minimum and maximum velocities
 		minimumVelocity = new double[problem.getNumberOfVariables()];

--- a/src/org/moeaframework/algorithm/single/DifferentialEvolution.java
+++ b/src/org/moeaframework/algorithm/single/DifferentialEvolution.java
@@ -22,10 +22,13 @@ import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.DominanceComparator;
+import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.real.DifferentialEvolutionSelection;
 import org.moeaframework.core.operator.real.DifferentialEvolutionVariation;
+import org.moeaframework.core.variable.RealVariable;
 
 /**
  * Single-objective differential evolution (DE) algorithm.
@@ -50,13 +53,20 @@ public class DifferentialEvolution extends AbstractEvolutionaryAlgorithm {
 	private final DifferentialEvolutionSelection selection;
 	
 	/**
-	 * The differential evolution variation operator.
+	 * Constructs a new single-objective differential evolution algorithm with default settings.
+	 * 
+	 * @param problem the problem
 	 */
-	private final DifferentialEvolutionVariation variation;
+	public DifferentialEvolution(Problem problem) {
+		this(problem,
+				new LinearDominanceComparator(),
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new DifferentialEvolutionSelection(),
+				new DifferentialEvolutionVariation());
+	}
 
 	/**
-	 * Constructs a new instance of the single-objective differential evolution
-	 * (DE) algorithm.
+	 * Constructs a new instance of the single-objective differential evolution (DE) algorithm.
 	 * 
 	 * @param problem the problem
 	 * @param comparator the aggregate objective comparator
@@ -64,15 +74,13 @@ public class DifferentialEvolution extends AbstractEvolutionaryAlgorithm {
 	 * @param selection the differential evolution selection operator
 	 * @param variation the differential evolution variation operator
 	 */
-	public DifferentialEvolution(Problem problem,
-			AggregateObjectiveComparator comparator,
-			Initialization initialization,
-			DifferentialEvolutionSelection selection,
-			DifferentialEvolutionVariation variation) {
-		super(problem, new Population(), null, initialization);
+	public DifferentialEvolution(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
+			DifferentialEvolutionSelection selection, DifferentialEvolutionVariation variation) {
+		super(problem, new Population(), null, initialization, variation);
 		this.comparator = comparator;
 		this.selection = selection;
-		this.variation = variation;
+		
+		problem.assertType(RealVariable.class);
 	}
 
 	@Override
@@ -106,4 +114,8 @@ public class DifferentialEvolution extends AbstractEvolutionaryAlgorithm {
 		return result;
 	}
 	
+	@Override
+	public DifferentialEvolutionVariation getVariation() {
+		return (DifferentialEvolutionVariation)variation;
+	}
 }

--- a/src/org/moeaframework/algorithm/single/EvolutionStrategy.java
+++ b/src/org/moeaframework/algorithm/single/EvolutionStrategy.java
@@ -18,13 +18,15 @@
 package org.moeaframework.algorithm.single;
 
 import org.moeaframework.algorithm.AbstractEvolutionaryAlgorithm;
-import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.Mutation;
+import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.core.variable.RealVariable;
 
 /**
  * Single-objective (mu + lambda) evolution strategy (ES) algorithm.  In this
@@ -46,11 +48,13 @@ public class EvolutionStrategy extends AbstractEvolutionaryAlgorithm {
 	 * The aggregate objective comparator.
 	 */
 	private final AggregateObjectiveComparator comparator;
-
-	/**
-	 * The variation operator.
-	 */
-	private final Variation variation;
+	
+	public EvolutionStrategy(Problem problem) {
+		this(problem,
+				new LinearDominanceComparator(),
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new SelfAdaptiveNormalVariation());
+	}
 
 	/**
 	 * Constructs a new instance of the evolution strategy (ES) algorithm.
@@ -58,19 +62,14 @@ public class EvolutionStrategy extends AbstractEvolutionaryAlgorithm {
 	 * @param problem the problem
 	 * @param comparator the aggregate objective comparator
 	 * @param initialization the initialization method
-	 * @param variation the variation operator
+	 * @param mutation the mutation operator
 	 */
-	public EvolutionStrategy(Problem problem,
-			AggregateObjectiveComparator comparator,
-			Initialization initialization,
-			Variation variation) {
-		super(problem, new Population(), null, initialization);
+	public EvolutionStrategy(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
+			Mutation mutation) {
+		super(problem, new Population(), null, initialization, mutation);
 		this.comparator = comparator;
-		this.variation = variation;
 		
-		if (variation.getArity() != 1) {
-			throw new FrameworkException("only supports variation operators with 1 parent");
-		}
+		problem.assertType(RealVariable.class);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
+++ b/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
@@ -26,8 +26,12 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Selection;
+import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.core.operator.TournamentSelection;
+import org.moeaframework.core.spi.OperatorFactory;
 
 /**
  * Single-objective genetic algorithm (GA) implementation with elitism.  A
@@ -52,14 +56,27 @@ public class GeneticAlgorithm extends AbstractEvolutionaryAlgorithm {
 	private final Selection selection;
 
 	/**
-	 * The mutation operator.
-	 */
-	private final Variation variation;
-	
-	/**
 	 * The solution with the best fitness score.
 	 */
 	private Solution eliteSolution;
+	
+	/**
+	 * Constructs a new instance of the genetic algorithm (GA) with default settings.
+	 * 
+	 * @param problem the problem
+	 */
+	public GeneticAlgorithm(Problem problem) {
+		this(problem,
+				new LinearDominanceComparator(),
+				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				OperatorFactory.getInstance().getVariation(problem));
+	}
+	
+	// Internal constructor to ensure tournament selection uses provided comparator
+	private GeneticAlgorithm(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
+			Variation variation) {
+		this(problem, comparator, initialization, new TournamentSelection(2, comparator), variation);
+	}
 
 	/**
 	 * Constructs a new instance of the genetic algorithm (GA).
@@ -70,14 +87,10 @@ public class GeneticAlgorithm extends AbstractEvolutionaryAlgorithm {
 	 * @param selection the selection operator
 	 * @param variation the variation operator
 	 */
-	public GeneticAlgorithm(Problem problem,
-			AggregateObjectiveComparator comparator,
-			Initialization initialization,
-			Selection selection,
-			Variation variation) {
-		super(problem, new Population(), null, initialization);
+	public GeneticAlgorithm(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
+			Selection selection, Variation variation) {
+		super(problem, new Population(), null, initialization, variation);
 		this.comparator = comparator;
-		this.variation = variation;
 		this.selection = selection;
 	}
 

--- a/src/org/moeaframework/algorithm/single/SelfAdaptiveNormalVariation.java
+++ b/src/org/moeaframework/algorithm/single/SelfAdaptiveNormalVariation.java
@@ -19,7 +19,7 @@ package org.moeaframework.algorithm.single;
 
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.RealVariable;
 
 /**
@@ -33,7 +33,7 @@ import org.moeaframework.core.variable.RealVariable;
  * where {@code N(0,1)} and {@code N(0,I)} are normally-distributed random
  * numbers with mean {@code 0} and standard deviation {@code 1}.
  */
-public class SelfAdaptiveNormalVariation implements Variation {
+public class SelfAdaptiveNormalVariation implements Mutation {
 	
 	/**
 	 * The attribute for storing the self adaptive parameter.
@@ -49,13 +49,8 @@ public class SelfAdaptiveNormalVariation implements Variation {
 	}
 
 	@Override
-	public int getArity() {
-		return 1;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution child = parents[0].copy();
+	public Solution mutate(Solution parent) {
+		Solution child = parent.copy();
 		double sigma = 1.0;
 		double tau = 1.0 / Math.sqrt(2.0 * child.getNumberOfVariables());
 		
@@ -80,7 +75,7 @@ public class SelfAdaptiveNormalVariation implements Variation {
 			variable.setValue(value);
 		}
 		
-		return new Solution[] { child };
+		return child;
 	}
 
 }

--- a/src/org/moeaframework/core/Algorithm.java
+++ b/src/org/moeaframework/core/Algorithm.java
@@ -21,6 +21,7 @@ import java.io.NotSerializableException;
 import java.io.Serializable;
 
 import org.moeaframework.algorithm.AlgorithmException;
+import org.moeaframework.core.termination.MaxFunctionEvaluations;
 
 /**
  * Interface for an optimization algorithm. An optimization algorithm operates
@@ -54,6 +55,28 @@ public interface Algorithm {
 	 * {@code true}.
 	 */
 	public void step();
+	
+	/**
+	 * Executes this algorithm for the given number of function evaluations.
+	 * 
+	 * @param evaluations the number of function evaluations
+	 */
+	public default void run(int evaluations) {
+		run(new MaxFunctionEvaluations(evaluations));
+	}
+	
+	/**
+	 * Executes this algorithm until the terminal condition signals it to stop.
+	 * 
+	 * @param terminationCondition the termination condition
+	 */
+	public default void run(TerminationCondition terminationCondition) {
+		terminationCondition.initialize(this);
+		
+		while (!isTerminated() && !terminationCondition.shouldTerminate(this)) {
+			step();
+		}
+	}
 
 	/**
 	 * Evaluates the specified solution for the problem being solved by this

--- a/src/org/moeaframework/core/Settings.java
+++ b/src/org/moeaframework/core/Settings.java
@@ -55,6 +55,11 @@ public class Settings {
 	public static final int BUFFER_SIZE = 0x1000;
 	
 	/**
+	 * The default population size.
+	 */
+	public static final int DEFAULT_POPULATION_SIZE = 100;
+	
+	/**
 	 * Store the new line character to prevent repetitive calls to
 	 * {@code System.getProperty("line.separator")}.
 	 */

--- a/src/org/moeaframework/core/operator/AbstractCompoundVariation.java
+++ b/src/org/moeaframework/core/operator/AbstractCompoundVariation.java
@@ -1,0 +1,140 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.operator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.moeaframework.core.FrameworkException;
+import org.moeaframework.core.Solution;
+import org.moeaframework.core.Variation;
+
+/**
+ * Construct a variation operator applying one or more variations sequentially.
+ * This construct is used to support mixed-type decision variables; however,
+ * this requires that the variation operators are type safe. Type safe variation
+ * operates only on supported types and ignores unsupported types.
+ * <p>
+ * {@code CompoundVariation} provides the following behavior:
+ * <ol>
+ *   <li>If the previous operator produced {@code K} offspring and the current
+ *       operator requires {@code K} parents, the current operator is applied
+ *       normally. The current operator may produce any number of offspring.
+ *   <li>If the previous operator produced {@code K} offspring and the current
+ *       operator requires {@code 1} parent, the current operator is applied to each
+ *       offspring individually. The current operator may produce any number of
+ *       offspring, but only the first offspring will be retained.
+ *   <li>Otherwise, an exception is thrown.
+ * </ol>
+ */
+public class AbstractCompoundVariation<T extends Variation> implements Variation, Iterable<T> {
+
+	/**
+	 * The variation operators in the order they are applied.
+	 */
+	protected final List<T> operators;
+	
+	/**
+	 * The name of this variation operator.
+	 */
+	private String name;
+
+	/**
+	 * Constructs a compound variation operator with no variation operators.
+	 */
+	public AbstractCompoundVariation() {
+		super();
+
+		operators = new ArrayList<T>();
+	}
+	
+	/**
+	 * Returns the name of this variation operator.  If no name has been
+	 * assigned through {@link #setName(String)}, a name is generated which
+	 * identifies the underlying operators.
+	 * 
+	 * @return the name of this variation operator
+	 */
+	public String getName() {
+		if (name == null) {
+			StringBuilder sb = new StringBuilder();
+			
+			for (Variation operator : operators) {
+				if (sb.length() > 0) {
+					sb.append('+');
+				}
+				
+				sb.append(operator.getClass().getSimpleName());
+			}
+			
+			return sb.toString();
+		} else {
+			return name;
+		}
+	}
+	
+	/**
+	 * Sets the name of this variation operator.
+	 * 
+	 * @param name the name of this variation operator
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * Appends the specified variation operator to this compound operator.
+	 * 
+	 * @param variation the variation operator to append
+	 */
+	public void appendOperator(T variation) {
+		operators.add(variation);
+	}
+
+	@Override
+	public Solution[] evolve(Solution[] parents) {
+		Solution[] result = Arrays.copyOf(parents, parents.length);
+
+		for (T operator : operators) {
+			if (result.length == operator.getArity()) {
+				result = operator.evolve(result);
+			} else if (operator.getArity() == 1) {
+				for (int j = 0; j < result.length; j++) {
+					result[j] = operator.evolve(new Solution[] { result[j] })[0];
+				}
+			} else {
+				throw new FrameworkException("invalid number of parents");
+			}
+		}
+
+		return result;
+	}
+
+	@Override
+	public int getArity() {
+		return operators.get(0).getArity();
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return operators.iterator();
+	}
+
+}

--- a/src/org/moeaframework/core/operator/AbstractMutation.java
+++ b/src/org/moeaframework/core/operator/AbstractMutation.java
@@ -1,0 +1,72 @@
+package org.moeaframework.core.operator;
+
+import org.moeaframework.core.PRNG;
+import org.moeaframework.core.Solution;
+import org.moeaframework.core.Variable;
+
+/**
+ * An abstract mutation class that supports mutating each decision variable with a
+ * given probability.
+ * 
+ * @param <T> the type of decision variable this operator supports
+ */
+public abstract class AbstractMutation<T extends Variable> implements Mutation {
+	
+	/**
+	 * The probability of mutating each decision variable.
+	 */
+	protected double probability;
+	
+	/**
+	 * The type of decision variable this operator supports.
+	 */
+	private Class<T> type;
+
+	/**
+	 * Constructs a new mutation operator for the given type.
+	 * 
+	 * @param type the type of decision variable this operator supports
+	 * @param probability the probability of mutating each decision variable
+	 */
+	public AbstractMutation(Class<T> type, double probability) {
+		super();
+		this.type = type;
+		this.probability = probability;
+	}
+	
+	/**
+	 * Returns the probability of mutating each decision variable
+	 * 
+	 * @return the probability between 0.0 and 1.0, inclusive
+	 */
+	public double getProbability() {
+		return probability;
+	}
+
+	/**
+	 * Sets the probability of mutating each decision variable.
+	 * 
+	 * @param probability the probability between 0.0 and 1.0, inclusive
+	 */
+	public void setProbability(double probability) {
+		this.probability = probability;
+	}
+
+	@Override
+	public Solution mutate(Solution parent) {
+		Solution result = parent.copy();
+
+		for (int i = 0; i < result.getNumberOfVariables(); i++) {
+			Variable variable = result.getVariable(i);
+
+			if ((PRNG.nextDouble() <= probability) && type.isInstance(variable)) {
+				mutate(type.cast(variable));
+			}
+		}
+
+		return result;
+	}
+	
+	public abstract void mutate(T variable);
+
+}

--- a/src/org/moeaframework/core/operator/CompoundMutation.java
+++ b/src/org/moeaframework/core/operator/CompoundMutation.java
@@ -1,0 +1,51 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.operator;
+
+import org.moeaframework.core.Solution;
+
+/**
+ * Versions of {@link CompoundVariation} that only supports mutation operators.
+ */
+public class CompoundMutation extends AbstractCompoundVariation<Mutation> implements Mutation {
+
+	/**
+	 * Constructs a compound mutation operator with the specified operators.
+	 * 
+	 * @param operators the mutation operators in the order they are applied
+	 */
+	public CompoundMutation(Mutation... operators) {
+		super();
+
+		for (Mutation operator : operators) {
+			appendOperator(operator);
+		}
+	}
+	
+	@Override
+	public Solution mutate(Solution parent) {
+		Solution result = parent.copy();
+
+		for (Mutation operator : operators) {
+			result = operator.mutate(result);
+		}
+
+		return result;
+	}
+
+}

--- a/src/org/moeaframework/core/operator/CompoundVariation.java
+++ b/src/org/moeaframework/core/operator/CompoundVariation.java
@@ -17,132 +17,25 @@
  */
 package org.moeaframework.core.operator;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.moeaframework.core.FrameworkException;
-import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 
 /**
  * Construct a variation operator applying one or more variations sequentially.
- * This construct is used to support mixed-type decision variables; however,
- * this requires that the variation operators are type safe. Type safe variation
- * operates only on supported types and ignores unsupported types.
- * <p>
- * {@code CompoundVariation} provides the following behavior:
- * <ol>
- * <li>If the previous operator produced {@code K} offspring and the current
- * operator requires {@code K} parents, the current operator is applied
- * normally. The current operator may produce any number of offspring.
- * <li>If the previous operator produced {@code K} offspring and the current
- * operator requires {@code 1} parent, the current operator is applied to each
- * offspring individually. The current operator may produce any number of
- * offspring, but only the first offspring will be retained.
- * <li>Otherwise, an exception is thrown.
- * </ol>
+ * See {@link AbstractCompoundVariation} for usage.
  */
-public class CompoundVariation implements Variation {
+public class CompoundVariation extends AbstractCompoundVariation<Variation> implements Variation {
 
 	/**
-	 * The variation operators in the order they are applied.
-	 */
-	private final List<Variation> operators;
-	
-	/**
-	 * The name of this variation operator.
-	 */
-	private String name;
-
-	/**
-	 * Constructs a compound variation operator with no variation operators.
-	 */
-	public CompoundVariation() {
-		super();
-
-		operators = new ArrayList<Variation>();
-	}
-
-	/**
-	 * Constructs a compound variation operator with the specified variation
-	 * operators.
+	 * Constructs a compound variation operator with the specified variation operators.
 	 * 
 	 * @param operators the variation operators in the order they are applied
 	 */
 	public CompoundVariation(Variation... operators) {
-		this();
+		super();
 
 		for (Variation operator : operators) {
 			appendOperator(operator);
 		}
-	}
-	
-	/**
-	 * Returns the name of this variation operator.  If no name has been
-	 * assigned through {@link #setName(String)}, a name is generated which
-	 * identifies the underlying operators.
-	 * 
-	 * @return the name of this variation operator
-	 */
-	public String getName() {
-		if (name == null) {
-			StringBuilder sb = new StringBuilder();
-			
-			for (Variation operator : operators) {
-				if (sb.length() > 0) {
-					sb.append('+');
-				}
-				
-				sb.append(operator.getClass().getSimpleName());
-			}
-			
-			return sb.toString();
-		} else {
-			return name;
-		}
-	}
-	
-	/**
-	 * Sets the name of this variation operator.
-	 * 
-	 * @param name the name of this variation operator
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	/**
-	 * Appends the specified variation operator to this compound operator.
-	 * 
-	 * @param variation the variation operator to append
-	 */
-	public void appendOperator(Variation variation) {
-		operators.add(variation);
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution[] result = Arrays.copyOf(parents, parents.length);
-
-		for (Variation operator : operators) {
-			if (result.length == operator.getArity()) {
-				result = operator.evolve(result);
-			} else if (operator.getArity() == 1) {
-				for (int j = 0; j < result.length; j++) {
-					result[j] = operator.evolve(new Solution[] { result[j] })[0];
-				}
-			} else {
-				throw new FrameworkException("invalid number of parents");
-			}
-		}
-
-		return result;
-	}
-
-	@Override
-	public int getArity() {
-		return operators.get(0).getArity();
 	}
 
 }

--- a/src/org/moeaframework/core/operator/GAVariation.java
+++ b/src/org/moeaframework/core/operator/GAVariation.java
@@ -33,7 +33,7 @@ public class GAVariation extends CompoundVariation {
 	 * @param crossover the crossover operator
 	 * @param mutation the mutation operator
 	 */
-	public GAVariation(Variation crossover, Variation mutation) {
+	public GAVariation(Variation crossover, Mutation mutation) {
 		super(crossover, mutation);
 		setName(crossover.getClass().getSimpleName());
 	}

--- a/src/org/moeaframework/core/operator/Mutation.java
+++ b/src/org/moeaframework/core/operator/Mutation.java
@@ -1,0 +1,29 @@
+package org.moeaframework.core.operator;
+
+import org.moeaframework.core.Solution;
+import org.moeaframework.core.Variation;
+
+/**
+ * Identifies mutation operators that evolve exactly one parent.
+ */
+public interface Mutation extends Variation {
+	
+	/**
+	 * Mutates the given parent to produce an offspring.
+	 * 
+	 * @param parent the parent solution
+	 * @return the offspring
+	 */
+	public Solution mutate(Solution parent);
+	
+	@Override
+	default public int getArity() {
+		return 1;
+	}
+
+	@Override
+	default public Solution[] evolve(Solution[] parents) {
+		return new Solution[] { mutate(parents[0]) };
+	}
+
+}

--- a/src/org/moeaframework/core/operator/binary/BitFlip.java
+++ b/src/org/moeaframework/core/operator/binary/BitFlip.java
@@ -20,7 +20,7 @@ package org.moeaframework.core.operator.binary;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.BinaryVariable;
 
 /**
@@ -29,12 +29,19 @@ import org.moeaframework.core.variable.BinaryVariable;
  * <p>
  * This operator is type-safe.
  */
-public class BitFlip implements Variation {
+public class BitFlip implements Mutation {
 
 	/**
 	 * The probability of flipping a bit.
 	 */
-	private final double probability;
+	private double probability;
+	
+	/**
+	 * Constructs a bit flip operator with the default settings.
+	 */
+	public BitFlip() {
+		this(0.01);
+	}
 
 	/**
 	 * Constructs a bit flip operator.
@@ -54,20 +61,29 @@ public class BitFlip implements Variation {
 	public double getProbability() {
 		return probability;
 	}
+	
+	/**
+	 * Sets the probability of flipping a bit.
+	 * 
+	 * @param probability the probability of flipping a bit
+	 */
+	public void setProbability(double probability) {
+		this.probability = probability;
+	}
 
 	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
+	public Solution mutate(Solution parent) {
+		Solution result = parent.copy();
 
 		for (int i = 0; i < result.getNumberOfVariables(); i++) {
 			Variable variable = result.getVariable(i);
 
 			if (variable instanceof BinaryVariable) {
-				evolve((BinaryVariable)variable, probability);
+				mutate((BinaryVariable)variable, probability);
 			}
 		}
 
-		return new Solution[] { result };
+		return result;
 	}
 
 	/**
@@ -76,17 +92,12 @@ public class BitFlip implements Variation {
 	 * @param variable the variable to be mutated
 	 * @param probability the probability of flipping a bit
 	 */
-	public static void evolve(BinaryVariable variable, double probability) {
+	public static void mutate(BinaryVariable variable, double probability) {
 		for (int i = 0; i < variable.getNumberOfBits(); i++) {
 			if (PRNG.nextDouble() <= probability) {
 				variable.set(i, !variable.get(i));
 			}
 		}
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/grammar/GrammarMutation.java
+++ b/src/org/moeaframework/core/operator/grammar/GrammarMutation.java
@@ -20,7 +20,7 @@ package org.moeaframework.core.operator.grammar;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.Grammar;
 
 /**
@@ -29,13 +29,19 @@ import org.moeaframework.core.variable.Grammar;
  * <p>
  * This variation operator is type-safe.
  */
-public class GrammarMutation implements Variation {
+public class GrammarMutation implements Mutation {
 
 	/**
-	 * The probability of mutating each integer codon in the grammar
-	 * representation.
+	 * The probability of mutating each integer codon in the grammar representation.
 	 */
-	private final double probability;
+	private double probability;
+	
+	/**
+	 * Constructs a uniform mutation operators for grammars.
+	 */
+	public GrammarMutation() {
+		this(1.0);
+	}
 
 	/**
 	 * Constructs a uniform mutation operator for grammars with the specified
@@ -49,19 +55,37 @@ public class GrammarMutation implements Variation {
 		this.probability = probability;
 	}
 
+	/**
+	 * Returns the probability of mutating each integer codon in the grammar representation.
+	 * 
+	 * @return the probability
+	 */
+	public double getProbability() {
+		return probability;
+	}
+
+	/**
+	 * Sets  the probability of mutating each integer codon in the grammar representation.
+	 * 
+	 * @param probability the probability (0.0 - 1.0)
+	 */
+	public void setProbability(double probability) {
+		this.probability = probability;
+	}
+
 	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result1 = parents[0].copy();
+	public Solution mutate(Solution parent) {
+		Solution result = parent.copy();
 
-		for (int i = 0; i < result1.getNumberOfVariables(); i++) {
-			Variable variable1 = result1.getVariable(i);
+		for (int i = 0; i < result.getNumberOfVariables(); i++) {
+			Variable variable = result.getVariable(i);
 
-			if (variable1 instanceof Grammar) {
-				evolve((Grammar)variable1, probability);
+			if (variable instanceof Grammar) {
+				mutate((Grammar)variable, probability);
 			}
 		}
 
-		return new Solution[] { result1 };
+		return result;
 	}
 
 	/**
@@ -73,17 +97,11 @@ public class GrammarMutation implements Variation {
 	 * @param probability the probability of mutating each integer codon in the
 	 *        grammar representation
 	 */
-	public static void evolve(Grammar grammar, double probability) {
+	public static void mutate(Grammar grammar, double probability) {
 		for (int i = 0; i < grammar.size(); i++) {
 			if (PRNG.nextDouble() <= probability) {
 				grammar.set(i, PRNG.nextInt(grammar.getMaximumValue()));
 			}
 		}
 	}
-
-	@Override
-	public int getArity() {
-		return 1;
-	}
-
 }

--- a/src/org/moeaframework/core/operator/permutation/Insertion.java
+++ b/src/org/moeaframework/core/operator/permutation/Insertion.java
@@ -18,9 +18,7 @@
 package org.moeaframework.core.operator.permutation;
 
 import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.AbstractMutation;
 import org.moeaframework.core.variable.Permutation;
 
 /**
@@ -29,38 +27,22 @@ import org.moeaframework.core.variable.Permutation;
  * <p>
  * This operator is type-safe.
  */
-public class Insertion implements Variation {
+public class Insertion extends AbstractMutation<Permutation> {
 
 	/**
-	 * The probability of mutating a variable.
+	 * Constructs an insertion mutation operator with the default settings.
 	 */
-	private final double probability;
+	public Insertion() {
+		this(0.3);
+	}
 
 	/**
-	 * Constructs an insertion mutation operator with the specified
-	 * probability of mutating a variable.
+	 * Constructs an insertion mutation operator with the specified probability of mutating a variable.
 	 * 
 	 * @param probability the probability of mutating a variable
 	 */
 	public Insertion(double probability) {
-		super();
-		this.probability = probability;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
-
-		for (int i = 0; i < result.getNumberOfVariables(); i++) {
-			Variable variable = result.getVariable(i);
-
-			if ((PRNG.nextDouble() <= probability)
-					&& (variable instanceof Permutation)) {
-				evolve((Permutation)variable);
-			}
-		}
-
-		return new Solution[] { result };
+		super(Permutation.class, probability);
 	}
 
 	/**
@@ -68,7 +50,7 @@ public class Insertion implements Variation {
 	 * 
 	 * @param permutation the permutation to be mutated
 	 */
-	public static void evolve(Permutation permutation) {
+	public void mutate(Permutation permutation) {
 		int i = PRNG.nextInt(permutation.size());
 		int j = PRNG.nextInt(permutation.size() - 1);
 
@@ -77,11 +59,6 @@ public class Insertion implements Variation {
 		}
 
 		permutation.insert(i, j);
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/permutation/Swap.java
+++ b/src/org/moeaframework/core/operator/permutation/Swap.java
@@ -18,9 +18,7 @@
 package org.moeaframework.core.operator.permutation;
 
 import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.AbstractMutation;
 import org.moeaframework.core.variable.Permutation;
 
 /**
@@ -29,46 +27,30 @@ import org.moeaframework.core.variable.Permutation;
  * <p>
  * This operator is type-safe.
  */
-public class Swap implements Variation {
+public class Swap extends AbstractMutation<Permutation> {
 
 	/**
-	 * The probability of mutating a variable.
+	 * Constructs a swap mutation operator with the default settings.
 	 */
-	private final double probability;
+	public Swap() {
+		this(0.3);
+	}
 
 	/**
-	 * Constructs a swap mutation operator with the specified probability of 
-	 * mutating a variable.
+	 * Constructs a swap mutation operator with the specified probability of mutating a variable.
 	 * 
 	 * @param probability the probability of mutating a variable
 	 */
 	public Swap(double probability) {
-		super();
-		this.probability = probability;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
-
-		for (int i = 0; i < result.getNumberOfVariables(); i++) {
-			Variable variable = result.getVariable(i);
-
-			if ((PRNG.nextDouble() <= probability)
-					&& (variable instanceof Permutation)) {
-				evolve((Permutation)variable);
-			}
-		}
-
-		return new Solution[] { result };
+		super(Permutation.class, probability);
 	}
 
 	/**
-	 * Evolves the specified permutation using the swap mutation operator.
+	 * Mutates the specified permutation using the swap mutation operator.
 	 * 
 	 * @param permutation the permutation to be mutated
 	 */
-	public static void evolve(Permutation permutation) {
+	public void mutate(Permutation permutation) {
 		int i = PRNG.nextInt(permutation.size());
 		int j = PRNG.nextInt(permutation.size() - 1);
 
@@ -77,11 +59,6 @@ public class Swap implements Variation {
 		}
 
 		permutation.swap(i, j);
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/program/PointMutation.java
+++ b/src/org/moeaframework/core/operator/program/PointMutation.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.Program;
 import org.moeaframework.util.tree.Node;
 import org.moeaframework.util.tree.Rules;
@@ -33,7 +33,7 @@ import org.moeaframework.util.tree.Rules;
  * <p>
  * This operator is type-safe.
  */
-public class PointMutation implements Variation {
+public class PointMutation implements Mutation {
 	
 	/**
 	 * The probability of mutating a node in the tree.
@@ -41,7 +41,14 @@ public class PointMutation implements Variation {
 	private double probability;
 	
 	/**
-	 * Constructs a new point mutation instance.
+	 * Constructs a new point mutation operator with the default settings.
+	 */
+	public PointMutation() {
+		this(1.0);
+	}
+	
+	/**
+	 * Constructs a new point mutation operator.
 	 * 
 	 * @param probability the probability of mutating a node in the tree
 	 */
@@ -50,14 +57,27 @@ public class PointMutation implements Variation {
 		this.probability = probability;
 	}
 
-	@Override
-	public int getArity() {
-		return 1;
+	/**
+	 * Gets the probability of mutating a node in the tree.
+	 * 
+	 * @return the probability
+	 */
+	public double getProbability() {
+		return probability;
+	}
+
+	/**
+	 * Sets the probability of mutating a node in the tree.
+	 * 
+	 * @param probability the probability (0.0 - 1.0)
+	 */
+	public void setProbability(double probability) {
+		this.probability = probability;
 	}
 
 	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
+	public Solution mutate(Solution parent) {
+		Solution result = parent.copy();
 		
 		for (int i = 0; i < result.getNumberOfVariables(); i++) {
 			Variable variable = result.getVariable(i);
@@ -68,7 +88,7 @@ public class PointMutation implements Variation {
 			}
 		}
 		
-		return new Solution[] { result };
+		return result;
 	}
 	
 	/**

--- a/src/org/moeaframework/core/operator/real/DifferentialEvolutionVariation.java
+++ b/src/org/moeaframework/core/operator/real/DifferentialEvolutionVariation.java
@@ -56,6 +56,13 @@ public class DifferentialEvolutionVariation implements Variation {
 	 * The scaling factor or step size.
 	 */
 	private final double F;
+	
+	/**
+	 * Constructs a differential evolution operator with default settings.
+	 */
+	public DifferentialEvolutionVariation() {
+		this(0.1, 0.5);
+	}
 
 	/**
 	 * Constructs a differential evolution operator with the specified crossover

--- a/src/org/moeaframework/core/operator/real/PM.java
+++ b/src/org/moeaframework/core/operator/real/PM.java
@@ -18,9 +18,7 @@
 package org.moeaframework.core.operator.real;
 
 import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.AbstractMutation;
 import org.moeaframework.core.variable.RealVariable;
 
 /**
@@ -45,69 +43,38 @@ import org.moeaframework.core.variable.RealVariable;
  *       26(4):30-45, 1996.
  * </ol>
  */
-public class PM implements Variation {
-
-	/**
-	 * The probability this operator is applied to each decision variable.
-	 */
-	private final double probability;
+public class PM extends AbstractMutation<RealVariable> {
 
 	/**
 	 * The distribution index controlling the shape of the polynomial mutation.
 	 */
-	private final double distributionIndex;
+	private double distributionIndex;
+	
+	/**
+	 * Constructs a polynomial mutation operator with the default parameters.
+	 */
+	public PM() {
+		this(0.1, 20.0);
+	}
 
 	/**
-	 * Constructs a polynomial mutation operator with the specified probability
-	 * and distribution index.
+	 * Constructs a polynomial mutation operator with the specified probability and distribution index.
 	 * 
-	 * @param probability the probability this operator is applied to each
-	 *        decision variable
-	 * @param distributionIndex the distribution index controlling the shape of
-	 *        the polynomial mutation.
+	 * @param probability the probability this operator is applied to each decision variable
+	 * @param distributionIndex the distribution index controlling the shape of the polynomial mutation.
 	 */
 	public PM(double probability, double distributionIndex) {
-		super();
-		this.probability = probability;
+		super(RealVariable.class, probability);
 		this.distributionIndex = distributionIndex;
 	}
-
+	
 	/**
-	 * Returns the probability this operator is applied to each decision
-	 * variable.
+	 * Returns the distribution index controlling the shape of the polynomial mutation.
 	 * 
-	 * @return the probability this operator is applied to each decision
-	 *         variable
-	 */
-	public double getProbability() {
-		return probability;
-	}
-
-	/**
-	 * Returns the distribution index controlling the shape of the polynomial
-	 * mutation.
-	 * 
-	 * @return the distribution index controlling the shape of the polynomial
-	 *         mutation
+	 * @return the distribution index controlling the shape of the polynomial mutation
 	 */
 	public double getDistributionIndex() {
 		return distributionIndex;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
-
-		for (int i = 0; i < result.getNumberOfVariables(); i++) {
-			Variable variable = result.getVariable(i);
-
-			if ((PRNG.nextDouble() <= probability)
-					&& (variable instanceof RealVariable)) {
-				evolve((RealVariable)variable, distributionIndex);
-			}
-		}
-
-		return new Solution[] { result };
 	}
 
 	/*
@@ -152,7 +119,7 @@ public class PM implements Variation {
 	 * @param distributionIndex the distribution index controlling the shape of
 	 *        the polynomial mutation
 	 */
-	public static void evolve(RealVariable v, double distributionIndex) {
+	public void mutate(RealVariable v) {
 		double u = PRNG.nextDouble();
 		double x = v.getValue();
 		double lb = v.getLowerBound();
@@ -162,13 +129,11 @@ public class PM implements Variation {
 
 		if (u < 0.5) {
 			double bl = (x - lb) / dx;
-			double b = 2 * u + (1 - 2 * u)
-					* (Math.pow(1 - bl, (distributionIndex + 1)));
+			double b = 2 * u + (1 - 2 * u) * (Math.pow(1 - bl, (distributionIndex + 1)));
 			delta = Math.pow(b, (1.0 / (distributionIndex + 1))) - 1.0;
 		} else {
 			double bu = (ub - x) / dx;
-			double b = 2 * (1 - u) + 2 * (u - 0.5)
-					* (Math.pow(1 - bu, (distributionIndex + 1)));
+			double b = 2 * (1 - u) + 2 * (u - 0.5) * (Math.pow(1 - bu, (distributionIndex + 1)));
 			delta = 1.0 - Math.pow(b, (1.0 / (distributionIndex + 1)));
 		}
 
@@ -181,11 +146,6 @@ public class PM implements Variation {
 		}
 
 		v.setValue(x);
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/real/SBX.java
+++ b/src/org/moeaframework/core/operator/real/SBX.java
@@ -50,30 +50,36 @@ public class SBX implements Variation {
 	/**
 	 * The probability of applying this SBX operator to each variable.
 	 */
-	private final double probability;
+	private double probability;
 
 	/**
 	 * The distribution index of this SBX operator.
 	 */
-	private final double distributionIndex;
+	private double distributionIndex;
 
 	/**
 	 * Enable randomly swapping decision variables between the parents.
 	 */
-	private final boolean swap;
+	private boolean swap;
 
 	/**
 	 * If {@code true}, use symmetric distributions; otherwise asymmetric
 	 * distributions are used.
 	 */
-	private final boolean symmetric;
+	private boolean symmetric;
+	
+	/**
+	 * Constructs a SBX operator with the default parameters.
+	 */
+	public SBX() {
+		this(1.0, 15.0);
+	}
 	
 	/**
 	 * Constructs a SBX operator with the specified probability and
 	 * distribution index.
 	 * 
-	 * @param probability the probability of applying this SBX operator to each
-	 *        variable
+	 * @param probability the probability of applying this SBX operator to each variable
 	 * @param distributionIndex the distribution index of this SBX operator
 	 */
 	public SBX(double probability, double distributionIndex) {
@@ -86,11 +92,9 @@ public class SBX implements Variation {
 	 * traditional SBX operation; and to {@code false} to use the SBX variant
 	 * used by NSGA-III.
 	 * 
-	 * @param probability the probability of applying this SBX operator to each
-	 *        variable
+	 * @param probability the probability of applying this SBX operator to each variable
 	 * @param distributionIndex the distribution index of this SBX operator
-	 * @param swap if {@code true}, randomly swap the variables between the two
-	 *        parents
+	 * @param swap if {@code true}, randomly swap the variables between the two parents
 	 * @param symmetric if {@code true}, symmetric distrubutions are used
 	 */
 	public SBX(double probability, double distributionIndex, boolean swap,
@@ -110,6 +114,15 @@ public class SBX implements Variation {
 	public double getProbability() {
 		return probability;
 	}
+	
+	/**
+	 * Sets the probability of applying this SBX operator to each variable.
+	 * 
+	 * @param probability the probability (0.0 - 1.0)
+	 */
+	public void setProbability(double probability) {
+		this.probability = probability;
+	}
 
 	/**
 	 * Returns the distribution index of this SBX operator.
@@ -119,17 +132,34 @@ public class SBX implements Variation {
 	public double getDistributionIndex() {
 		return distributionIndex;
 	}
+	
+	/**
+	 * Sets the distribution index of this SBX operator.
+	 * 
+	 * @param distributionIndex the distribution index
+	 */
+	public void setDistributionIndex(double distributionIndex) {
+		this.distributionIndex = distributionIndex;
+	}
 
 	/**
 	 * Returns {@code true} if this SBX operator swaps variables between the
 	 * two parents.  Disabling this swapping produces offspring closer to the
 	 * two parents, which is beneficial for NSGA-III.
 	 * 
-	 * @return {@code true} if this SBX operator swaps variables between the
-	 *         two parents
+	 * @return {@code true} if this SBX operator swaps variables between the two parents
 	 */
 	public boolean isSwap() {
 		return swap;
+	}
+	
+	/**
+	 * Sets whether this SBX operator swaps variables between the two parents.
+	 * 
+	 * @param swap {@code true} if this SBX operator swaps variables between the two parents
+	 */
+	public void setSwap(boolean swap) {
+		this.swap = swap;
 	}
 
 	/**
@@ -141,6 +171,16 @@ public class SBX implements Variation {
 	 */
 	public boolean isSymmetric() {
 		return symmetric;
+	}
+	
+	/**
+	 * Sets if offspring are distributed symmetrically or asymmetrically.
+	 * 
+	 * @param symmetric {@code true} if the offspring are distributed symmetrically; or
+	 *         {@code false} if asymmetric distributions are used
+	 */
+	public void setSymmetric(boolean symmetric) {
+		this.symmetric = symmetric;
 	}
 
 	@Override

--- a/src/org/moeaframework/core/operator/real/UM.java
+++ b/src/org/moeaframework/core/operator/real/UM.java
@@ -18,9 +18,7 @@
 package org.moeaframework.core.operator.real;
 
 import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.AbstractMutation;
 import org.moeaframework.core.variable.RealVariable;
 
 /**
@@ -36,47 +34,22 @@ import org.moeaframework.core.variable.RealVariable;
  * <p>
  * This operator is type-safe.
  */
-public class UM implements Variation {
-
+public class UM extends AbstractMutation<RealVariable> {
+	
 	/**
-	 * The probability of mutating each variable in a solution.
+	 * Constructs a uniform mutation operator with default settings.
 	 */
-	private final double probability;
+	public UM() {
+		this(0.1);
+	}
 
 	/**
 	 * Constructs a uniform mutation operator.
 	 * 
-	 * @param probability the probability of mutating each variable in a
-	 *        solution
+	 * @param probability the probability of mutating each variable in a solution
 	 */
 	public UM(double probability) {
-		super();
-		this.probability = probability;
-	}
-
-	/**
-	 * Returns the probability of mutating each variable in a solution.
-	 * 
-	 * @return the probability of mutating each variable in a solution
-	 */
-	public double getProbability() {
-		return probability;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
-
-		for (int i = 0; i < result.getNumberOfVariables(); i++) {
-			Variable variable = result.getVariable(i);
-
-			if ((PRNG.nextDouble() <= probability)
-					&& (variable instanceof RealVariable)) {
-				evolve((RealVariable)variable);
-			}
-		}
-
-		return new Solution[] { result };
+		super(RealVariable.class, probability);
 	}
 
 	/**
@@ -84,14 +57,8 @@ public class UM implements Variation {
 	 * 
 	 * @param variable the variable to be mutated
 	 */
-	public static void evolve(RealVariable variable) {
-		variable.setValue(PRNG.nextDouble(variable.getLowerBound(), variable
-				.getUpperBound()));
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
+	public void mutate(RealVariable variable) {
+		variable.setValue(PRNG.nextDouble(variable.getLowerBound(), variable.getUpperBound()));
 	}
 
 }

--- a/src/org/moeaframework/core/operator/subset/Add.java
+++ b/src/org/moeaframework/core/operator/subset/Add.java
@@ -17,10 +17,7 @@
  */
 package org.moeaframework.core.operator.subset;
 
-import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.AbstractMutation;
 import org.moeaframework.core.variable.Subset;
 
 /**
@@ -28,54 +25,34 @@ import org.moeaframework.core.variable.Subset;
  * <p>
  * This operator is type-safe.
  */
-public class Add implements Variation {
+public class Add extends AbstractMutation<Subset> {
 
 	/**
-	 * The probability of mutating a variable.
+	 * Constructs an add mutation operators with the default settings.
 	 */
-	private final double probability;
+	public Add() {
+		this(0.1);
+	}
 
 	/**
-	 * Constructs an add mutation operator with the specified
-	 * probability of mutating a variable.
+	 * Constructs an add mutation operator with the specified probability of mutating a variable.
 	 * 
 	 * @param probability the probability of mutating a variable
 	 */
 	public Add(double probability) {
-		super();
-		this.probability = probability;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
-
-		for (int i = 0; i < result.getNumberOfVariables(); i++) {
-			Variable variable = result.getVariable(i);
-
-			if ((PRNG.nextDouble() <= probability)
-					&& (variable instanceof Subset)) {
-				evolve((Subset)variable);
-			}
-		}
-
-		return new Solution[] { result };
+		super(Subset.class, probability);
 	}
 
 	/**
-	 * Evolves the specified subset using the add mutation operator.
+	 * Mutates the specified subset using the add mutation operator.
 	 * 
 	 * @param subset the subset to be mutated
 	 */
-	public static void evolve(Subset subset) {
+	@Override
+	public void mutate(Subset subset) {
 		if (subset.size() < subset.getU()) {
 			subset.add(subset.randomNonmember());
 		}
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/subset/Remove.java
+++ b/src/org/moeaframework/core/operator/subset/Remove.java
@@ -17,10 +17,7 @@
  */
 package org.moeaframework.core.operator.subset;
 
-import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.AbstractMutation;
 import org.moeaframework.core.variable.Subset;
 
 /**
@@ -28,54 +25,33 @@ import org.moeaframework.core.variable.Subset;
  * <p>
  * This operator is type-safe.
  */
-public class Remove implements Variation {
-
+public class Remove extends AbstractMutation<Subset> {
+	
 	/**
-	 * The probability of mutating a variable.
+	 * Constructs a remove mutation operator with the default settings.
 	 */
-	private final double probability;
+	public Remove() {
+		this(0.1);
+	}
 
 	/**
-	 * Constructs a remove mutation operator with the specified
-	 * probability of mutating a variable.
+	 * Constructs a remove mutation operator with the specified probability of mutating a variable.
 	 * 
 	 * @param probability the probability of mutating a variable
 	 */
 	public Remove(double probability) {
-		super();
-		this.probability = probability;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
-
-		for (int i = 0; i < result.getNumberOfVariables(); i++) {
-			Variable variable = result.getVariable(i);
-
-			if ((PRNG.nextDouble() <= probability)
-					&& (variable instanceof Subset)) {
-				evolve((Subset)variable);
-			}
-		}
-
-		return new Solution[] { result };
+		super(Subset.class, probability);
 	}
 
 	/**
-	 * Evolves the specified subset using the remove mutation operator.
+	 * Mutates the specified subset using the remove mutation operator.
 	 * 
 	 * @param subset the subset to be mutated
 	 */
-	public static void evolve(Subset subset) {
+	public void mutate(Subset subset) {
 		if (subset.size() > subset.getL()) {
 			subset.remove(subset.randomMember());
 		}
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/subset/Replace.java
+++ b/src/org/moeaframework/core/operator/subset/Replace.java
@@ -17,66 +17,41 @@
  */
 package org.moeaframework.core.operator.subset;
 
-import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Solution;
-import org.moeaframework.core.Variable;
-import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.AbstractMutation;
 import org.moeaframework.core.variable.Subset;
 
 /**
- * Replacement mutation operator.  Randomly replaces one of the members in the
- * subset with a non-member.
+ * Replacement mutation operator.  Randomly replaces one of the members in the subset with a non-member.
  * <p>
  * This operator is type-safe.
  */
-public class Replace implements Variation {
-
+public class Replace extends AbstractMutation<Subset> {
+	
 	/**
-	 * The probability of mutating a variable.
+	 * Constructs a replacement mutation operator with default settings.
 	 */
-	private final double probability;
+	public Replace() {
+		this(0.3);
+	}
 
 	/**
-	 * Constructs a replacement mutation operator with the specified
-	 * probability of mutating a variable.
+	 * Constructs a replacement mutation operator with the specified probability of mutating a variable.
 	 * 
 	 * @param probability the probability of mutating a variable
 	 */
 	public Replace(double probability) {
-		super();
-		this.probability = probability;
-	}
-
-	@Override
-	public Solution[] evolve(Solution[] parents) {
-		Solution result = parents[0].copy();
-
-		for (int i = 0; i < result.getNumberOfVariables(); i++) {
-			Variable variable = result.getVariable(i);
-
-			if ((PRNG.nextDouble() <= probability)
-					&& (variable instanceof Subset)) {
-				evolve((Subset)variable);
-			}
-		}
-
-		return new Solution[] { result };
+		super(Subset.class, probability);
 	}
 
 	/**
-	 * Evolves the specified subset using the replacement mutation operator.
+	 * Mutates the specified subset using the replacement mutation operator.
 	 * 
 	 * @param subset the subset to be mutated
 	 */
-	public static void evolve(Subset subset) {
+	public void mutate(Subset subset) {
 		if ((subset.size() < subset.getN()) && (subset.size() > 0)) {
 			subset.replace(subset.randomMember(), subset.randomNonmember());
 		}
-	}
-
-	@Override
-	public int getArity() {
-		return 1;
 	}
 
 }

--- a/src/org/moeaframework/core/spi/OperatorFactory.java
+++ b/src/org/moeaframework/core/spi/OperatorFactory.java
@@ -18,9 +18,11 @@
 package org.moeaframework.core.spi;
 
 import java.util.ServiceConfigurationError;
+
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.operator.CompoundVariation;
+import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.util.TypedProperties;
 
 /**
@@ -81,6 +83,7 @@ public class OperatorFactory extends AbstractFactory<OperatorProvider> {
 	 * @throws ProviderLookupException if no default mutation operator could
 	 *         be determined
 	 */
+	@Deprecated
 	public String getDefaultMutation(Problem problem) {
 		String result = lookupMutationHint(problem);
 		
@@ -101,6 +104,7 @@ public class OperatorFactory extends AbstractFactory<OperatorProvider> {
 	 * @throws ProviderLookupException if no default variation operator could
 	 *         be determined
 	 */
+	@Deprecated
 	public String getDefaultVariation(Problem problem) {
 		String result = lookupVariationHint(problem);
 		
@@ -109,6 +113,44 @@ public class OperatorFactory extends AbstractFactory<OperatorProvider> {
 		}
 		
 		return result;
+	}
+	
+	/**
+	 * Returns the suggested mutation operator for the given problem.
+	 * 
+	 * @param problem the problem
+	 * @return an instance of the mutation operator
+	 */
+	public Mutation getMutation(Problem problem) {
+		String hint = lookupMutationHint(problem);
+		Variation variation = getVariation(hint, new TypedProperties(), problem);
+		
+		if (!(variation instanceof Mutation)) {
+			throw new ProviderLookupException("the operator '" + hint + "' is not a mutation operator");
+		}
+		
+		return (Mutation)variation;
+	}
+	
+	/**
+	 * Returns the suggested variation operator for the given problem.
+	 * 
+	 * @param problem the problem to be solved
+	 * @return an instance of the variation operator
+	 */
+	public Variation getVariation(Problem problem) {
+		return getVariation(null, problem);
+	}
+	
+	/**
+	 * Returns the named variation operator using default settings.
+	 * 
+	 * @param name the name identifying the variation operator
+	 * @param problem the problem to be solved
+	 * @return an instance of the variation operator
+	 */
+	public Variation getVariation(String name, Problem problem) {
+		return getVariation(name, new TypedProperties(), problem);
 	}
 
 	/**
@@ -120,7 +162,7 @@ public class OperatorFactory extends AbstractFactory<OperatorProvider> {
 	 * @param name the name identifying the variation operator
 	 * @param properties the implementation-specific properties
 	 * @param problem the problem to be solved
-	 * @return an instance of the variation operator with the specified name
+	 * @return an instance of the variation operator
 	 * @throws ProviderNotFoundException if no provider for the algorithm is 
 	 *         available
 	 */

--- a/src/org/moeaframework/core/spi/OperatorFactory.java
+++ b/src/org/moeaframework/core/spi/OperatorFactory.java
@@ -21,6 +21,7 @@ import java.util.ServiceConfigurationError;
 
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.operator.CompoundMutation;
 import org.moeaframework.core.operator.CompoundVariation;
 import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.util.TypedProperties;
@@ -178,15 +179,38 @@ public class OperatorFactory extends AbstractFactory<OperatorProvider> {
 			}
 		} else if (name.contains("+")) {
 			String[] entries = name.split("\\+");
-			CompoundVariation variation = new CompoundVariation();
+			Variation[] operators = new Variation[entries.length];
 			
-			for (String entry : entries) {
-				variation.appendOperator(getVariation(entry.trim(), properties, problem));
+			for (int i = 0; i < entries.length; i++) {
+				operators[i] = getVariation(entries[i].trim(), properties, problem);
 			}
 			
-			return variation;
+			return createCompoundOperator(operators);
 		} else {
 			return instantiateVariation(name, properties, problem);
+		}
+	}
+	
+	private Variation createCompoundOperator(Variation[] operators) {
+		boolean isMutation = true;
+		
+		for (int i = 0; i < operators.length; i++) {
+			if (!(operators[i] instanceof Mutation)) {
+				isMutation = false;
+				break;
+			}
+		}
+		
+		if (isMutation) {
+			Mutation[] mutation = new Mutation[operators.length];
+
+			for (int i = 0; i < operators.length; i++) {
+				mutation[i] = (Mutation)operators[i];
+			}
+			
+			return new CompoundMutation(mutation);
+		} else {
+			return new CompoundVariation(operators);
 		}
 	}
 	

--- a/src/org/moeaframework/core/termination/MaxFunctionEvaluations.java
+++ b/src/org/moeaframework/core/termination/MaxFunctionEvaluations.java
@@ -21,10 +21,14 @@ import org.moeaframework.core.Algorithm;
 import org.moeaframework.core.TerminationCondition;
 
 /**
- * Terminates a run when the maximum number of function evaluations is
- * exceeded.
+ * Terminates a run when the maximum number of function evaluations is exceeded.
  */
 public class MaxFunctionEvaluations implements TerminationCondition {
+	
+	/**
+	 * The number of function evaluations at the start.
+	 */
+	private int startingEvaluations;
 	
 	/**
 	 * The maximum number of function evaluations.
@@ -44,12 +48,12 @@ public class MaxFunctionEvaluations implements TerminationCondition {
 
 	@Override
 	public void initialize(Algorithm algorithm) {
-		// do nothing
+		startingEvaluations = algorithm.getNumberOfEvaluations();
 	}
 
 	@Override
 	public boolean shouldTerminate(Algorithm algorithm) {
-		return algorithm.getNumberOfEvaluations() >= maxEvaluations;
+		return (algorithm.getNumberOfEvaluations() - startingEvaluations) >= maxEvaluations;
 	}
 
 }

--- a/src/org/moeaframework/util/weights/NormalBoundaryDivisions.java
+++ b/src/org/moeaframework/util/weights/NormalBoundaryDivisions.java
@@ -109,6 +109,16 @@ public class NormalBoundaryDivisions {
 			return new NormalBoundaryDivisions((int)properties.getDouble("divisions", 4));
 		}
 		
+		return forProblem(problem);
+	}
+	
+	/**
+	 * Returns the default number of divisions based on the number of objectives.
+	 * 
+	 * @param problem the problem
+	 * @return the reference point divisions
+	 */
+	public static NormalBoundaryDivisions forProblem(Problem problem) {
 		int divisionsOuter;
 		int divisionsInner;
 		

--- a/test/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithmTest.java
+++ b/test/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithmTest.java
@@ -27,7 +27,9 @@ import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
+import org.moeaframework.core.Variation;
 import org.moeaframework.core.operator.RandomInitialization;
+import org.moeaframework.core.spi.OperatorFactory;
 import org.moeaframework.core.spi.ProblemFactory;
 
 /**
@@ -47,9 +49,10 @@ public class AbstractEvolutionaryAlgorithmTest {
 		Population population = new Population();
 		NondominatedPopulation archive = new NondominatedPopulation();
 		Initialization initialization = new RandomInitialization(problem, 50);
+		Variation variation = OperatorFactory.getInstance().getVariation(problem);
 
 		return new AbstractEvolutionaryAlgorithm(problem, population, archive,
-				initialization) {
+				initialization, variation) {
 
 			@Override
 			protected void iterate() {

--- a/test/org/moeaframework/core/operator/binary/BitFlipTest.java
+++ b/test/org/moeaframework/core/operator/binary/BitFlipTest.java
@@ -62,7 +62,7 @@ public class BitFlipTest {
 		for (int i = 0; i < TestThresholds.SAMPLES; i++) {
 			BinaryVariable original = new BinaryVariable(100);
 			BinaryVariable mutated = original.copy();
-			BitFlip.evolve(mutated, probability);
+			BitFlip.mutate(mutated, probability);
 
 			sum += original.hammingDistance(mutated);
 		}

--- a/test/org/moeaframework/core/operator/binary/HUXTest.java
+++ b/test/org/moeaframework/core/operator/binary/HUXTest.java
@@ -47,8 +47,8 @@ public class HUXTest {
 			BinaryVariable parent1 = new BinaryVariable(100);
 			BinaryVariable parent2 = new BinaryVariable(100);
 
-			BitFlip.evolve(parent1, 0.5);
-			BitFlip.evolve(parent2, 0.5);
+			BitFlip.mutate(parent1, 0.5);
+			BitFlip.mutate(parent2, 0.5);
 
 			BinaryVariable offspring1 = parent1.copy();
 			BinaryVariable offspring2 = parent2.copy();
@@ -75,8 +75,8 @@ public class HUXTest {
 			BinaryVariable parent1 = new BinaryVariable(100);
 			BinaryVariable parent2 = new BinaryVariable(100);
 
-			BitFlip.evolve(parent1, 0.5);
-			BitFlip.evolve(parent2, 0.5);
+			BitFlip.mutate(parent1, 0.5);
+			BitFlip.mutate(parent2, 0.5);
 
 			BinaryVariable offspring1 = parent1.copy();
 			BinaryVariable offspring2 = parent2.copy();
@@ -106,8 +106,8 @@ public class HUXTest {
 		BinaryVariable bv1 = new BinaryVariable(100);
 		BinaryVariable bv2 = new BinaryVariable(100);
 
-		BitFlip.evolve(bv1, 0.5);
-		BitFlip.evolve(bv2, 0.5);
+		BitFlip.mutate(bv1, 0.5);
+		BitFlip.mutate(bv2, 0.5);
 
 		Solution s1 = new Solution(1, 0);
 		s1.setVariable(0, bv1);

--- a/test/org/moeaframework/core/spi/TestAlgorithmProvider.java
+++ b/test/org/moeaframework/core/spi/TestAlgorithmProvider.java
@@ -33,7 +33,8 @@ public class TestAlgorithmProvider extends AlgorithmProvider {
 					problem,
 					new Population(),
 					null,
-					new RandomInitialization(problem, 100)) {
+					new RandomInitialization(problem, 100),
+					OperatorFactory.getInstance().getVariation(problem)) {
 
 				@Override
 				protected void iterate() {


### PR DESCRIPTION
Adds simple constructors for algorithms in an effort to simplify creating algorithms directly from their class.  This also adds a default `run` implementation to `Algorithm` so you can execute them directly.  With these changes, the following is possible:

```java

Problem problem = new DTLZ2(3);
NSGAII algorithm = new NSGAII(problem);

algorithm.run(10000);

NondominatedPopulation result = algorithm.getResult();
```

When created this way, the algorithm is initialized with its default or suggested parameters.  This is essentially identical to running:

```java

NondominatedPopulation result = new Executor()
    .withProblem("DTLZ2_3")
    .withAlgorithm("NSGAII")
    .withMaxEvaluations(10000)
    .run();
```

(There are a few exceptions that will be addressed later, namely NSGA-III and e-NSGA-II.  These algorithms do not have concrete implementations.)