### PR TITLE
Adding configuration API

### DIFF
--- a/examples/org/moeaframework/examples/prototype/Example.java
+++ b/examples/org/moeaframework/examples/prototype/Example.java
@@ -1,9 +1,10 @@
 package org.moeaframework.examples.prototype;
+
+import java.io.IOException;
 import org.moeaframework.algorithm.NSGAII;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
-import org.moeaframework.core.operator.real.PCX;
 import org.moeaframework.problem.DTLZ.DTLZ2;
 
 /**
@@ -12,11 +13,10 @@ import org.moeaframework.problem.DTLZ.DTLZ2;
  */
 public class Example {
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws IOException {
 		Problem problem = new DTLZ2(2);
 		
 		NSGAII algorithm = new NSGAII(problem);
-		algorithm.setVariation(new PCX(10, 2));
 		algorithm.run(10000);
 
 		NondominatedPopulation result = algorithm.getResult();

--- a/src/org/moeaframework/algorithm/AbstractAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractAlgorithm.java
@@ -127,10 +127,7 @@ public abstract class AbstractAlgorithm implements Algorithm {
 	 *         been initialized
 	 */
 	protected void initialize() {
-		if (initialized) {
-			throw new AlgorithmInitializationException(this, "algorithm already initialized");
-		}
-
+		assertNotInitialized();
 		initialized = true;
 	}
 
@@ -143,6 +140,16 @@ public abstract class AbstractAlgorithm implements Algorithm {
 	 */
 	public boolean isInitialized() {
 		return initialized;
+	}
+	
+	/**
+	 * Throws an exception if the algorithm is initialized.  Use this anywhere
+	 * to check and fail if the algorithm is already initialized.
+	 */
+	public void assertNotInitialized() {
+		if (initialized) {
+			throw new AlgorithmInitializationException(this, "algorithm already initialized");
+		}
 	}
 
 	/**

--- a/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
@@ -42,6 +42,11 @@ import org.moeaframework.core.configuration.Configurable;
  */
 public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 		implements EvolutionaryAlgorithm, Configurable {
+	
+	/**
+	 * The initial population size.
+	 */
+	protected int initialPopulationSize;
 
 	/**
 	 * The current population.
@@ -67,14 +72,16 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 	 * Constructs an abstract evolutionary algorithm.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population
 	 * @param archive the archive storing the non-dominated solutions
 	 * @param initialization the initialization operator
 	 * @param variation the variation operator
 	 */
-	public AbstractEvolutionaryAlgorithm(Problem problem, Population population, NondominatedPopulation archive,
-			Initialization initialization, Variation variation) {
+	public AbstractEvolutionaryAlgorithm(Problem problem, int initialPopulationSize, Population population,
+			NondominatedPopulation archive, Initialization initialization, Variation variation) {
 		super(problem);
+		this.initialPopulationSize = initialPopulationSize;
 		this.population = population;
 		this.archive = archive;
 		this.initialization = initialization;
@@ -102,7 +109,7 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 
 		Population population = getPopulation();
 		NondominatedPopulation archive = getArchive();
-		Solution[] initialSolutions = initialization.initialize();
+		Solution[] initialSolutions = initialization.initialize(initialPopulationSize);
 		
 		evaluateAll(initialSolutions);
 		population.addAll(initialSolutions);
@@ -120,6 +127,25 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 	protected void setArchive(NondominatedPopulation archive) {
 		assertNotInitialized();
 		this.archive = archive;
+	}
+	
+	/**
+	 * Returns the initial population size.
+	 * 
+	 * @return the initial population size
+	 */
+	public int getInitialPopulationSize() {
+		return initialPopulationSize;
+	}
+	
+	/**
+	 * Sets the initial population size.  This value can not be set after initialization.
+	 * 
+	 * @param initialPopulationSize the initial population size
+	 */
+	protected void setInitialPopulationSize(int initialPopulationSize) {
+		assertNotInitialized();
+		this.initialPopulationSize = initialPopulationSize;
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
@@ -29,6 +29,7 @@ import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Configurable;
 
 /**
  * Abstract class providing default implementations for several
@@ -40,17 +41,17 @@ import org.moeaframework.core.Variation;
  * {@link #iterate()} method.
  */
 public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
-		implements EvolutionaryAlgorithm {
+		implements EvolutionaryAlgorithm, Configurable {
 
 	/**
 	 * The current population.
 	 */
-	protected final Population population;
+	protected Population population; // TODO: Make these fields private to ensure callers go through the getters / setters
 
 	/**
 	 * The archive storing the non-dominated solutions.
 	 */
-	protected final NondominatedPopulation archive;
+	protected NondominatedPopulation archive;
 
 	/**
 	 * The initialization operator.
@@ -115,10 +116,20 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 	public NondominatedPopulation getArchive() {
 		return archive;
 	}
+	
+	protected void setArchive(NondominatedPopulation archive) {
+		assertNotInitialized();
+		this.archive = archive;
+	}
 
 	@Override
 	public Population getPopulation() {
 		return population;
+	}
+	
+	protected void setPopulation(Population population) {
+		assertNotInitialized();
+		this.population = population;
 	}
 	
 	/**
@@ -142,8 +153,7 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 	@Override
 	public Serializable getState() throws NotSerializableException {
 		if (!isInitialized()) {
-			throw new AlgorithmInitializationException(this, 
-					"algorithm not initialized");
+			throw new AlgorithmInitializationException(this, "algorithm not initialized");
 		}
 
 		List<Solution> populationList = new ArrayList<Solution>();

--- a/src/org/moeaframework/algorithm/AdaptiveTimeContinuation.java
+++ b/src/org/moeaframework/algorithm/AdaptiveTimeContinuation.java
@@ -27,6 +27,8 @@ import org.moeaframework.core.Population;
 import org.moeaframework.core.Selection;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Configurable;
+import org.moeaframework.core.configuration.Property;
 
 /**
  * Decorator for {@link EvolutionaryAlgorithm}s to add time continuation
@@ -55,28 +57,28 @@ import org.moeaframework.core.Variation;
  *       Water Resources, 29(6):792-807, 2006.
  * </ol>
  */
-public class AdaptiveTimeContinuation extends PeriodicAction implements EvolutionaryAlgorithm {
+public class AdaptiveTimeContinuation extends PeriodicAction implements EvolutionaryAlgorithm, Configurable {
 
 	/**
 	 * The maximum number of iterations allowed since the last restart before 
 	 * forcing a restart.
 	 */
-	private final int maxWindowSize;
+	private int maxWindowSize;
 
 	/**
-	 * The population-to-archive ratio.
+	 * The percentage of the population that, during a restart, are introduced into the new population.
 	 */
-	private final double populationRatio;
+	private double injectionRate;
 
 	/**
 	 * The minimum size of the population.
 	 */
-	private final int minimumPopulationSize;
+	private int minimumPopulationSize;
 
 	/**
 	 * The maximum size of the population.
 	 */
-	private final int maximumPopulationSize;
+	private int maximumPopulationSize;
 
 	/**
 	 * The selection operator for selecting solutions from the archive during a
@@ -107,7 +109,7 @@ public class AdaptiveTimeContinuation extends PeriodicAction implements Evolutio
 	 * @param windowSize the number of iterations between invocations of {@code check}
 	 * @param maxWindowSize the maximum number of iterations allowed since the
 	 *        last restart before forcing a restart
-	 * @param populationRatio the population-to-archive ratio
+	 * @param injectionRate the injection rate percentage
 	 * @param minimumPopulationSize the minimum size of the population
 	 * @param maximumPopulationSize the maximum size of the population
 	 * @param restartSelection the selection operator for selecting solutions from the
@@ -116,18 +118,114 @@ public class AdaptiveTimeContinuation extends PeriodicAction implements Evolutio
 	 *        from the archive during a restart
 	 */
 	public AdaptiveTimeContinuation(EvolutionaryAlgorithm algorithm,
-			int windowSize, int maxWindowSize, double populationRatio,
+			int windowSize, int maxWindowSize, double injectionRate,
 			int minimumPopulationSize, int maximumPopulationSize,
 			Selection restartSelection, Variation restartVariation) {
 		super(algorithm, windowSize, FrequencyType.STEPS);
 		this.maxWindowSize = maxWindowSize;
-		this.populationRatio = populationRatio;
+		this.injectionRate = injectionRate;
 		this.minimumPopulationSize = minimumPopulationSize;
 		this.maximumPopulationSize = maximumPopulationSize;
 		this.restartSelection = restartSelection;
 		this.restartVariation = restartVariation;
 
 		listeners = EventListenerSupport.create(RestartListener.class);
+	}
+	
+	/**
+	 * Returns the number of iterations between invocations of {@code check}.
+	 * 
+	 * @return the window size, in iterations
+	 */
+	public int getWindowSize() {
+		return frequency;
+	}
+	
+	/**
+	 * Sets the number of iterations between invocations of {@code check}.
+	 * 
+	 * @param windowSize the window size, in iterations
+	 */
+	@Property
+	public void setWindowSize(int windowSize) {
+		this.frequency = windowSize;
+	}
+
+	/**
+	 * Returns the maximum number of iterations allowed since the last restart before forcing a restart.
+	 * 
+	 * @return the maximum window size, in iterations
+	 */
+	public int getMaxWindowSize() {
+		return maxWindowSize;
+	}
+
+	/**
+	 * Sets the maximum number of iterations allowed since the last restart before forcing a restart.
+	 * 
+	 * @param maxWindowSize the maximum window size, in iterations
+	 */
+	@Property
+	public void setMaxWindowSize(int maxWindowSize) {
+		this.maxWindowSize = maxWindowSize;
+	}
+
+	/**
+	 * Returns the percentage of the population that, during a restart, are introduced into the new population.
+	 * 
+	 * @return the injection rate
+	 */
+	public double getInjectionRate() {
+		return injectionRate;
+	}
+
+	/**
+	 * Sets the percentage of the population that, during a restart, are introduced into the new population.  The
+	 * population will be resized to hold {@code archive.size() / injectionRate} solutions.
+	 * 
+	 * @param injectionRate the injection rate
+	 */
+	@Property
+	public void setInjectionRate(double injectionRate) {
+		this.injectionRate = injectionRate;
+	}
+
+	/**
+	 * Returns the minimum size of the population.
+	 * 
+	 * @return the minimum size of the population
+	 */
+	public int getMinimumPopulationSize() {
+		return minimumPopulationSize;
+	}
+
+	/**
+	 * Sets the minimum size of the population.
+	 * 
+	 * @param minimumPopulationSize the minimum size of the population
+	 */
+	@Property
+	public void setMinimumPopulationSize(int minimumPopulationSize) {
+		this.minimumPopulationSize = minimumPopulationSize;
+	}
+
+	/**
+	 * Returns the maximum size of the population.
+	 * 
+	 * @return the maximum size of the population
+	 */
+	public int getMaximumPopulationSize() {
+		return maximumPopulationSize;
+	}
+
+	/**
+	 * Sets the maximum size of the population.
+	 * 
+	 * @param maximumPopulationSize the maximum size of the population
+	 */
+	@Property
+	public void setMaximumPopulationSize(int maximumPopulationSize) {
+		this.maximumPopulationSize = maximumPopulationSize;
 	}
 
 	/**
@@ -164,7 +262,7 @@ public class AdaptiveTimeContinuation extends PeriodicAction implements Evolutio
 	 */
 	protected RestartType check() {
 		int populationSize = getPopulation().size();
-		double targetSize = populationRatio * getArchive().size();
+		double targetSize = getArchive().size() / injectionRate;
 
 		if (iteration - iterationAtLastRestart >= maxWindowSize) {
 			return RestartType.HARD;
@@ -195,7 +293,7 @@ public class AdaptiveTimeContinuation extends PeriodicAction implements Evolutio
 			population.addAll(archive);
 		}
 
-		int newPopulationSize = (int)(populationRatio * archive.size());
+		int newPopulationSize = (int)(archive.size() / injectionRate);
 
 		if (newPopulationSize < minimumPopulationSize) {
 			newPopulationSize = minimumPopulationSize;

--- a/src/org/moeaframework/algorithm/DBEA.java
+++ b/src/org/moeaframework/algorithm/DBEA.java
@@ -34,8 +34,10 @@ import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.ObjectiveComparator;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.TypedProperties;
 import org.moeaframework.util.weights.NormalBoundaryDivisions;
 import org.moeaframework.util.weights.NormalBoundaryIntersectionGenerator;
 
@@ -101,7 +103,7 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	/**
 	 * The number of divisions for generating reference points.
 	 */
-	private final NormalBoundaryDivisions divisions;
+	private NormalBoundaryDivisions divisions;
 	
 	/**
 	 * Constructs a new instance of the DBEA algorithm with default settings.
@@ -137,6 +139,32 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 			Variation variation, NormalBoundaryDivisions divisions) {
 		super(problem, new Population(), null, initialization, variation);
 		this.divisions = divisions;
+	}
+	
+	/**
+	 * Returns the number of divisions used to generate reference points.
+	 * 
+	 * @return the number of divisions
+	 */
+	public NormalBoundaryDivisions getDivisions() {
+		return divisions;
+	}
+	
+	/**
+	 * Sets the number of divisions used to generate reference points.  This method can only be called
+	 * before initializing the algorithm.
+	 * 
+	 * @param divisions the number of divisions
+	 */
+	public void setDivisions(NormalBoundaryDivisions divisions) {
+		assertNotInitialized();
+		this.divisions = divisions;
+	}
+	
+	@Override
+	@Property("operator")
+	public void setVariation(Variation variation) {
+		super.setVariation(variation);
 	}
 
 	@Override
@@ -750,8 +778,21 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	@Override
-	public void setVariation(Variation variation) {
-		super.setVariation(variation);
+	public void applyConfiguration(TypedProperties properties) {		
+		NormalBoundaryDivisions divisions = NormalBoundaryDivisions.tryFromProperties(properties);
+		
+		if (divisions != null) {
+			setPopulation(new ReferencePointNondominatedSortingPopulation(problem.getNumberOfObjectives(), divisions));
+		}
+		
+		super.applyConfiguration(properties);
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		properties.addAll(divisions.toProperties());
+		return properties;
 	}
 
 }

--- a/src/org/moeaframework/algorithm/DBEA.java
+++ b/src/org/moeaframework/algorithm/DBEA.java
@@ -122,7 +122,8 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	 */
 	public DBEA(Problem problem, NormalBoundaryDivisions divisions) {
 		this(problem,
-				new RandomInitialization(problem, divisions.getNumberOfReferencePoints(problem)),
+				divisions.getNumberOfReferencePoints(problem),
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getVariation(problem),
 				divisions);
 	}
@@ -131,13 +132,14 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	 * Constructs a new instance of the DBEA algorithm.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param initialization the initialization method
 	 * @param variation the variation operator
 	 * @param divisions the number of divisions
 	 */
-	public DBEA(Problem problem, Initialization initialization,
+	public DBEA(Problem problem, int initialPopulationSize, Initialization initialization,
 			Variation variation, NormalBoundaryDivisions divisions) {
-		super(problem, new Population(), null, initialization, variation);
+		super(problem, initialPopulationSize, new Population(), null, initialization, variation);
 		this.divisions = divisions;
 	}
 	
@@ -165,6 +167,12 @@ public class DBEA extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/DefaultAlgorithms.java
+++ b/src/org/moeaframework/algorithm/DefaultAlgorithms.java
@@ -344,7 +344,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 				initialization,
 				properties.getInt("windowSize", 100),
 				Math.max(properties.getInt("windowSize", 100), properties.getInt("maxWindowSize", 100)),
-				1.0 / properties.getDouble("injectionRate", 0.25),
+				properties.getDouble("injectionRate", 0.25),
 				properties.getInt("minimumPopulationSize", 100),
 				properties.getInt("maximumPopulationSize", 10000));
 	}

--- a/src/org/moeaframework/algorithm/DefaultAlgorithms.java
+++ b/src/org/moeaframework/algorithm/DefaultAlgorithms.java
@@ -115,7 +115,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 	private Algorithm neweMOEA(TypedProperties properties, Problem problem) {
 		int populationSize = (int)properties.getDouble("populationSize", 100);
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		Population population = new Population();
 
 		DominanceComparator comparator = new ParetoDominanceComparator();
@@ -127,7 +127,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		TournamentSelection selection = new TournamentSelection(2, comparator);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 
-		return new EpsilonMOEA(problem, population, archive,
+		return new EpsilonMOEA(problem, populationSize, population, archive,
 				selection, variation, initialization, comparator);
 	}
 
@@ -141,7 +141,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 	private Algorithm newNSGAII(TypedProperties properties, Problem problem) {
 		int populationSize = (int)properties.getDouble("populationSize", 100);
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		NondominatedSortingPopulation population = new NondominatedSortingPopulation();
 		TournamentSelection selection = null;
 		
@@ -153,7 +153,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 
-		return new NSGAII(problem, population, null, selection, variation, initialization);
+		return new NSGAII(problem, populationSize, population, null, selection, variation, initialization);
 	}
 	
 	/**
@@ -177,7 +177,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 			populationSize = (int)Math.ceil(referencePoints / 4.0) * 4;
 		}
 		
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		
 		ReferencePointNondominatedSortingPopulation population = new ReferencePointNondominatedSortingPopulation(
 				problem.getNumberOfObjectives(), divisions);
@@ -231,7 +231,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 
-		return new NSGAIII(problem, population, selection, variation, initialization);
+		return new NSGAIII(problem, populationSize, population, selection, variation, initialization);
 	}
 
 	/**
@@ -251,7 +251,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 			populationSize = problem.getNumberOfObjectives();
 		}
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		
 		//default to de+pm for real-encodings
 		String operator = properties.getString("operator", null);
@@ -280,6 +280,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 
 		return new MOEAD(
 				problem,
+				populationSize,
 				neighborhoodSize,
 				initialization,
 				variation,
@@ -303,12 +304,12 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		
 		DominanceComparator comparator = new ParetoDominanceComparator();
 		NondominatedSortingPopulation population = new NondominatedSortingPopulation(comparator);
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		DifferentialEvolutionSelection selection = new DifferentialEvolutionSelection();
 		DifferentialEvolutionVariation variation = (DifferentialEvolutionVariation)OperatorFactory
 				.getInstance().getVariation("de", properties, problem);
 
-		return new GDE3(problem, population, comparator, selection, variation, initialization);
+		return new GDE3(problem, populationSize, population, comparator, selection, variation, initialization);
 	}
 
 	/**
@@ -321,7 +322,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 	private Algorithm neweNSGAII(TypedProperties properties, Problem problem) {
 		int populationSize = (int)properties.getDouble("populationSize", 100);
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 
 		NondominatedSortingPopulation population = new NondominatedSortingPopulation(
 				new ParetoDominanceComparator());
@@ -337,6 +338,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		
 		return new EpsilonNSGAII(
 				problem,
+				populationSize,
 				population,
 				archive,
 				selection,
@@ -406,10 +408,10 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		int offspringSize = (int)properties.getDouble("offspringSize", 100);
 		int k = (int)properties.getDouble("k", 1);
 		
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 
-		return new SPEA2(problem, initialization, variation, offspringSize, k);
+		return new SPEA2(problem, populationSize, initialization, variation, offspringSize, k);
 	}
 	
 	/**
@@ -439,10 +441,10 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		int archiveSize = (int)properties.getDouble("archiveSize", 100);
 		int bisections = (int)properties.getDouble("bisections", 8);
 		
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 
-		return new PESA2(problem, variation, initialization, bisections, archiveSize);
+		return new PESA2(problem, populationSize, variation, initialization, bisections, archiveSize);
 	}
 	
 	/**
@@ -501,8 +503,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		String indicator = properties.getString("indicator", "hypervolume");
 		IndicatorFitnessEvaluator fitnessEvaluator = null;
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
-
+		Initialization initialization = new RandomInitialization(problem);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 		
 		if ("hypervolume".equalsIgnoreCase(indicator)) {
@@ -513,7 +514,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 			throw new IllegalArgumentException("invalid indicator: " + indicator);
 		}
 
-		return new IBEA(problem, null, initialization, variation, fitnessEvaluator);
+		return new IBEA(problem, populationSize, null, initialization, variation, fitnessEvaluator);
 	}
 	
 	/**
@@ -529,15 +530,14 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		String indicator = properties.getString("indicator", "hypervolume");
 		FitnessEvaluator fitnessEvaluator = null;
 		
-		Initialization initialization = new RandomInitialization(problem, populationSize);
-
+		Initialization initialization = new RandomInitialization(problem);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 		
 		if ("hypervolume".equalsIgnoreCase(indicator)) {
 			fitnessEvaluator = new HypervolumeContributionFitnessEvaluator(problem, offset);
 		}
 
-		return new SMSEMOA(problem, initialization, variation, fitnessEvaluator);
+		return new SMSEMOA(problem, populationSize, initialization, variation, fitnessEvaluator);
 	}
 	
 	/**
@@ -550,10 +550,10 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 	private Algorithm newVEGA(TypedProperties properties, Problem problem) {
 		int populationSize = (int)properties.getDouble("populationSize", 100);
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 		
-		return new VEGA(problem, new Population(), null, initialization, variation);
+		return new VEGA(problem, populationSize, new Population(), null, initialization, variation);
 	}
 	
 	/**
@@ -567,10 +567,10 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		NormalBoundaryDivisions divisions = NormalBoundaryDivisions.fromProperties(properties, problem);
 		int populationSize = divisions.getNumberOfReferencePoints(problem);
 		
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 		
-		return new DBEA(problem, initialization, variation, divisions);
+		return new DBEA(problem, populationSize, initialization, variation, divisions);
 	}
 	
 	/**
@@ -589,7 +589,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		NormalBoundaryDivisions divisions = NormalBoundaryDivisions.fromProperties(properties, problem);
 		int populationSize = divisions.getNumberOfReferencePoints(problem);
 		
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		
 		ReferenceVectorGuidedPopulation population = new ReferenceVectorGuidedPopulation(
 				problem.getNumberOfObjectives(), divisions,
@@ -614,7 +614,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		int maxGenerations = (int)(properties.getDouble("maxEvaluations", 10000) / populationSize);
 		int adaptFrequency = (int)properties.getDouble("adaptFrequency", maxGenerations / 10);
 
-		return new RVEA(problem, population, variation, initialization, maxGenerations, adaptFrequency);
+		return new RVEA(problem, populationSize, population, variation, initialization, maxGenerations, adaptFrequency);
 	}
 	
 	/**
@@ -626,8 +626,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 	 */
 	private Algorithm newRandomSearch(TypedProperties properties, Problem problem) {
 		int populationSize = (int)properties.getDouble("populationSize", 100);
-		
-		Initialization generator = new RandomInitialization(problem, populationSize);
+		Initialization generator = new RandomInitialization(problem);
 		
 		NondominatedPopulation archive = null;
 		
@@ -638,7 +637,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 			archive = new NondominatedPopulation();
 		}
 		
-		return new RandomSearch(problem, generator, archive);
+		return new RandomSearch(problem, populationSize, generator, archive);
 	}
 	
 	/**
@@ -654,7 +653,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		int populationSize = (int)properties.getDouble("populationSize", 100);
 		int numberOfWeights = (int)properties.getDouble("numberOfWeights", 50);
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		List<double[]> weights = MSOPS.generateWeights(problem, numberOfWeights);
 		
 		MSOPSRankedPopulation population = new MSOPSRankedPopulation(weights);
@@ -662,7 +661,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		DifferentialEvolutionVariation variation = (DifferentialEvolutionVariation)OperatorFactory.getInstance().getVariation(
 				"de", properties, problem);
 
-		return new MSOPS(problem, population, selection, variation, initialization);
+		return new MSOPS(problem, populationSize, population, selection, variation, initialization);
 	}
 	
 	/**
@@ -705,11 +704,11 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 			throw new FrameworkException("unrecognized weighting method: " + method);
 		}
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		Selection selection = new TournamentSelection(2, comparator);
 		Variation variation = OperatorFactory.getInstance().getVariation(null, properties, problem);
 
-		return new GeneticAlgorithm(problem, comparator, initialization, selection, variation);
+		return new GeneticAlgorithm(problem, populationSize, comparator, initialization, selection, variation);
 	}
 	
 	/**
@@ -736,10 +735,10 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 			throw new FrameworkException("unrecognized weighting method: " + method);
 		}
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		SelfAdaptiveNormalVariation variation = new SelfAdaptiveNormalVariation();
 
-		return new EvolutionStrategy(problem, comparator, initialization, variation);
+		return new EvolutionStrategy(problem, populationSize, comparator, initialization, variation);
 	}
 
 	/**
@@ -766,12 +765,12 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 			throw new FrameworkException("unrecognized weighting method: " + method);
 		}
 
-		Initialization initialization = new RandomInitialization(problem, populationSize);
+		Initialization initialization = new RandomInitialization(problem);
 		DifferentialEvolutionSelection selection = new DifferentialEvolutionSelection();
 		DifferentialEvolutionVariation variation = (DifferentialEvolutionVariation)OperatorFactory.getInstance()
 				.getVariation("de", properties, problem);
 
-		return new DifferentialEvolution(problem, comparator, initialization, selection, variation);
+		return new DifferentialEvolution(problem, populationSize, comparator, initialization, selection, variation);
 	}
 	
 	private Algorithm newAMOSA(TypedProperties properties, Problem problem) {
@@ -792,12 +791,12 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 		int numberOfHillClimbingIterationsForRefinement = properties.getInt("hillClimbIter", 20);
 			
 		// Initialize the algorithm with randomly-generated solutions
-		Initialization initialization = new RandomInitialization(problem, (int)gamma*softLimit);
+		Initialization initialization = new RandomInitialization(problem);
 			
 		// Use the operator factory that problem provides
 		Mutation mutation = OperatorFactory.getInstance().getMutation(properties, problem);
 
-		return new AMOSA(problem, initialization, mutation, softLimit, hardLimit, tMin, tMax,
+		return new AMOSA(problem, initialization, mutation, gamma, softLimit, hardLimit, tMin, tMax,
 				alpha, numberOfIterationPerTemperature, numberOfHillClimbingIterationsForRefinement);
 	}
 	

--- a/src/org/moeaframework/algorithm/EpsilonMOEA.java
+++ b/src/org/moeaframework/algorithm/EpsilonMOEA.java
@@ -34,9 +34,11 @@ import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.TournamentSelection;
 import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.TypedProperties;
 
 /**
  * Implementation of the &epsilon;-MOEA algorithm.  The &epsilon;-MOEA is a
@@ -167,9 +169,30 @@ public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements Epsilo
 		return (EpsilonBoxDominanceArchive)super.getArchive();
 	}
 	
+	public void setArchive(EpsilonBoxDominanceArchive archive) {
+		super.setArchive(archive);
+	}
+	
 	@Override
+	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	public void applyConfiguration(TypedProperties properties) {
+		if (properties.contains("epsilon")) {
+			setArchive(new EpsilonBoxDominanceArchive(properties.getDoubleArray("epsilon", null)));
+		}
+		
+		super.applyConfiguration(properties);
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		properties.setDoubleArray("epsilon", getArchive().getComparator().getEpsilons().toArray());
+		return properties;
 	}
 
 }

--- a/src/org/moeaframework/algorithm/EpsilonMOEA.java
+++ b/src/org/moeaframework/algorithm/EpsilonMOEA.java
@@ -71,32 +71,37 @@ public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements Epsilo
 	 */
 	public EpsilonMOEA(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new Population(),
 				new EpsilonBoxDominanceArchive(EpsilonHelper.getEpsilon(problem)),
 				new TournamentSelection(2),
 				OperatorFactory.getInstance().getVariation(problem),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE));
+				new RandomInitialization(problem));
 	}
 
 	/**
 	 * Constructs the &epsilon;-MOEA algorithm with the specified components.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population used to store solutions
 	 * @param archive the archive used to store the result
 	 * @param selection the selection operator
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
 	 */
-	public EpsilonMOEA(Problem problem, Population population, EpsilonBoxDominanceArchive archive, Selection selection,
-			Variation variation, Initialization initialization) {
-		this(problem, population, archive, selection, variation, initialization, new ParetoDominanceComparator());
+	public EpsilonMOEA(Problem problem, int initialPopulationSize, Population population,
+			EpsilonBoxDominanceArchive archive, Selection selection, Variation variation,
+			Initialization initialization) {
+		this(problem, initialPopulationSize, population, archive, selection, variation, initialization,
+				new ParetoDominanceComparator());
 	}
 
 	/**
 	 * Constructs the &epsilon;-MOEA algorithm with the specified components.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population used to store solutions
 	 * @param archive the archive used to store the result
 	 * @param selection the selection operator
@@ -104,9 +109,10 @@ public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements Epsilo
 	 * @param initialization the initialization method
 	 * @param dominanceComparator the dominance comparator used by the {@link #addToPopulation} method
 	 */
-	public EpsilonMOEA(Problem problem, Population population, EpsilonBoxDominanceArchive archive, Selection selection,
-			Variation variation, Initialization initialization, DominanceComparator dominanceComparator) {
-		super(problem, population, archive, initialization, variation);
+	public EpsilonMOEA(Problem problem, int initialPopulationSize, Population population,
+			EpsilonBoxDominanceArchive archive, Selection selection, Variation variation,
+			Initialization initialization, DominanceComparator dominanceComparator) {
+		super(problem, initialPopulationSize, population, archive, initialization, variation);
 		this.selection = selection;
 		this.dominanceComparator = dominanceComparator;
 	}
@@ -177,6 +183,12 @@ public class EpsilonMOEA extends AbstractEvolutionaryAlgorithm implements Epsilo
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 	
 	@Override

--- a/src/org/moeaframework/algorithm/EpsilonNSGAII.java
+++ b/src/org/moeaframework/algorithm/EpsilonNSGAII.java
@@ -40,11 +40,12 @@ public class EpsilonNSGAII extends AdaptiveTimeContinuation implements Configura
 	 */
 	public EpsilonNSGAII(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new NondominatedSortingPopulation(),
 				new EpsilonBoxDominanceArchive(EpsilonHelper.getEpsilon(problem)),
 				new TournamentSelection(2, new ChainedComparator(new ParetoDominanceComparator(), new CrowdingComparator())),
 				OperatorFactory.getInstance().getVariation(problem),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new RandomInitialization(problem),
 				100, // windowSize
 				100, // maxwindowSize
 				0.25, // injectionRate
@@ -56,23 +57,23 @@ public class EpsilonNSGAII extends AdaptiveTimeContinuation implements Configura
 	 * Constructs the &epsilon;-NSGA-II instance with the specified components.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population used to store solutions
 	 * @param archive the &epsilon;-dominance archive
 	 * @param selection the selection operator
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
 	 * @param windowSize the number of iterations between invocations of {@code check}
-	 * @param maxWindowSize the maximum number of iterations allowed since the
-	 *        last restart before forcing a restart
+	 * @param maxWindowSize the maximum number of iterations allowed since the last restart before forcing a restart
 	 * @param injectionRate the injection rate
 	 * @param minimumPopulationSize the minimum size of the population
 	 * @param maximumPopulationSize the maximum size of the population
 	 */
-	public EpsilonNSGAII(Problem problem, NondominatedSortingPopulation population,
+	public EpsilonNSGAII(Problem problem, int initialPopulationSize, NondominatedSortingPopulation population,
 			EpsilonBoxDominanceArchive archive, Selection selection, Variation variation,
 			Initialization initialization, int windowSize, int maxWindowSize, double injectionRate,
 			int minimumPopulationSize, int maximumPopulationSize) {
-		super(new NSGAII(problem, population, archive, selection, variation, initialization),
+		super(new NSGAII(problem, initialPopulationSize, population, archive, selection, variation, initialization),
 				windowSize, maxWindowSize, injectionRate, minimumPopulationSize, maximumPopulationSize,
 				new UniformSelection(), new UM(1.0));
 	}
@@ -94,6 +95,11 @@ public class EpsilonNSGAII extends AdaptiveTimeContinuation implements Configura
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		getAlgorithm().setVariation(variation);
+	}
+	
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		getAlgorithm().setInitialPopulationSize(initialPopulationSize);
 	}
 	
 	public EpsilonBoxDominanceArchive getArchive() {

--- a/src/org/moeaframework/algorithm/EpsilonProgressContinuation.java
+++ b/src/org/moeaframework/algorithm/EpsilonProgressContinuation.java
@@ -55,7 +55,7 @@ public class EpsilonProgressContinuation extends AdaptiveTimeContinuation {
 	 *        {@code check}
 	 * @param maxWindowSize the maximum number of iterations allowed since the
 	 *        last restart before forcing a restart
-	 * @param populationRatio the population-to-archive ratio
+	 * @param injectionRate the injection rate
 	 * @param minimumPopulationSize the minimum size of the population
 	 * @param maximumPopulationSize the maximum size of the population
 	 * @param selection the selection operator for selecting solutions from the
@@ -65,10 +65,10 @@ public class EpsilonProgressContinuation extends AdaptiveTimeContinuation {
 	 */
 	public EpsilonProgressContinuation(
 			EpsilonBoxEvolutionaryAlgorithm algorithm, int windowSize,
-			int maxWindowSize, double populationRatio,
+			int maxWindowSize, double injectionRate,
 			int minimumPopulationSize, int maximumPopulationSize,
 			Selection selection, Variation variation) {
-		super(algorithm, windowSize, maxWindowSize, populationRatio,
+		super(algorithm, windowSize, maxWindowSize, injectionRate,
 				minimumPopulationSize, maximumPopulationSize, selection,
 				variation);
 	}

--- a/src/org/moeaframework/algorithm/GDE3.java
+++ b/src/org/moeaframework/algorithm/GDE3.java
@@ -60,17 +60,19 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 	 */
 	public GDE3(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new NondominatedSortingPopulation(),
 				new ParetoDominanceComparator(), // TODO: we should get this from NondominatedSortingPopulation
 				new DifferentialEvolutionSelection(),
 				new DifferentialEvolutionVariation(),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE));
+				new RandomInitialization(problem));
 	}
 
 	/**
 	 * Constructs the GDE3 algorithm with the specified components.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population used to store solutions
 	 * @param comparator the dominance comparator used to determine if offspring
 	 *        survive until the non-dominated sorting step
@@ -78,10 +80,10 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
 	 */
-	public GDE3(Problem problem, NondominatedSortingPopulation population, DominanceComparator comparator,
-			DifferentialEvolutionSelection selection, DifferentialEvolutionVariation variation,
-			Initialization initialization) {
-		super(problem, population, null, initialization, variation);
+	public GDE3(Problem problem, int initialPopulationSize, NondominatedSortingPopulation population,
+			DominanceComparator comparator, DifferentialEvolutionSelection selection,
+			DifferentialEvolutionVariation variation, Initialization initialization) {
+		super(problem, initialPopulationSize, population, null, initialization, variation);
 		this.comparator = comparator;
 		this.selection = selection;
 		
@@ -139,6 +141,12 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(DifferentialEvolutionVariation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 
 }

--- a/src/org/moeaframework/algorithm/GDE3.java
+++ b/src/org/moeaframework/algorithm/GDE3.java
@@ -25,6 +25,7 @@ import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.real.DifferentialEvolutionSelection;
 import org.moeaframework.core.operator.real.DifferentialEvolutionVariation;
@@ -135,6 +136,7 @@ public class GDE3 extends AbstractEvolutionaryAlgorithm {
 		return (DifferentialEvolutionVariation)super.getVariation();
 	}
 	
+	@Property("operator")
 	public void setVariation(DifferentialEvolutionVariation variation) {
 		super.setVariation(variation);
 	}

--- a/src/org/moeaframework/algorithm/IBEA.java
+++ b/src/org/moeaframework/algorithm/IBEA.java
@@ -75,8 +75,9 @@ public class IBEA extends AbstractEvolutionaryAlgorithm {
 	 */
 	public IBEA(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				null,
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getVariation(problem),
 				new HypervolumeFitnessEvaluator(problem));
 	}
@@ -85,14 +86,15 @@ public class IBEA extends AbstractEvolutionaryAlgorithm {
 	 * Constructs a new IBEA instance.
 	 * 
 	 * @param problem the problem
+	 * @param initialPopulationSize the initial population size
 	 * @param archive the external archive; or {@code null} if no external archive is used
 	 * @param initialization the initialization operator
 	 * @param variation the variation operator
 	 * @param fitnessEvaluator the indicator fitness evaluator to use (e.g., hypervolume additive-epsilon indicator)
 	 */
-	public IBEA(Problem problem, NondominatedPopulation archive, Initialization initialization, Variation variation,
-			IndicatorFitnessEvaluator fitnessEvaluator) {
-		super(problem, new Population(), archive, initialization, variation);
+	public IBEA(Problem problem, int initialPopulationSize, NondominatedPopulation archive,
+			Initialization initialization, Variation variation, IndicatorFitnessEvaluator fitnessEvaluator) {
+		super(problem, initialPopulationSize, new Population(), archive, initialization, variation);
 		setFitnessEvaluator(fitnessEvaluator);
 
 		selection = new TournamentSelection(fitnessComparator);
@@ -161,6 +163,12 @@ public class IBEA extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 	
 	@Override

--- a/src/org/moeaframework/algorithm/MOEAD.java
+++ b/src/org/moeaframework/algorithm/MOEAD.java
@@ -34,6 +34,8 @@ import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Configurable;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.AbstractCompoundVariation;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.real.DifferentialEvolutionVariation;
@@ -50,15 +52,15 @@ import org.moeaframework.util.weights.WeightGenerator;
  * <p>
  * References:
  * <ol>
- * <li>Li, H. and Zhang, Q. "Multiobjective Optimization problems with
- * Complicated Pareto Sets, MOEA/D and NSGA-II." IEEE Transactions on
- * Evolutionary Computation, 13(2):284-302, 2009.
- * <li>Zhang, Q., et al.  "The Performance of a New Version of MOEA/D on
- * CEC09 Unconstrained MOP Test Instances."  IEEE Congress on Evolutionary
- * Computation, 2009.
+ *   <li>Li, H. and Zhang, Q. "Multiobjective Optimization problems with
+ *       Complicated Pareto Sets, MOEA/D and NSGA-II." IEEE Transactions on
+ *       Evolutionary Computation, 13(2):284-302, 2009.
+ *   <li>Zhang, Q., et al.  "The Performance of a New Version of MOEA/D on
+ *       CEC09 Unconstrained MOP Test Instances."  IEEE Congress on Evolutionary
+ *       Computation, 2009.
  * </ol>
  */
-public class MOEAD extends AbstractAlgorithm {
+public class MOEAD extends AbstractAlgorithm implements Configurable {
 
 	/**
 	 * The current population.
@@ -73,7 +75,7 @@ public class MOEAD extends AbstractAlgorithm {
 	/**
 	 * The size of the neighborhood used for mating.
 	 */
-	private final int neighborhoodSize;
+	private int neighborhoodSize;
 	
 	/**
 	 * The weight generator; or {@code null} if the default weight generator is used.
@@ -83,12 +85,12 @@ public class MOEAD extends AbstractAlgorithm {
 	/**
 	 * The probability of mating with a solution in the neighborhood rather than the entire population.
 	 */
-	private final double delta;
+	private double delta;
 
 	/**
 	 * The maximum number of population slots a solution can replace.
 	 */
-	private final double eta;
+	private double eta;
 
 	/**
 	 * The initialization operator.
@@ -104,12 +106,13 @@ public class MOEAD extends AbstractAlgorithm {
 	 * The frequency, in generations, in which utility values are updated.  Set to {@code -1} to disable
 	 * utility-based search.  [2] recommends to update every {@code 50} generations.
 	 */
-	private final int updateUtility;
+	private int updateUtility;
 
 	/**
-	 * Set to {@code true} if using differential evolution.
+	 * Set to {@code true} if using differential evolution.  This ensures the parents are ordered correctly
+	 * for differential evolution variation.
 	 */
-	final boolean useDE;
+	boolean useDE;
 	
 	/**
 	 * The current generation number.
@@ -180,7 +183,7 @@ public class MOEAD extends AbstractAlgorithm {
 	 * @param delta the probability of mating with a solution in the neighborhood rather than the entire population
 	 * @param eta the maximum number of population slots a solution can replace
 	 * @param updateUtility the frequency, in generations, in which utility values are updated; set to {@code 50} to
-	 *        use the recommended update frequency or {@code -1} to disable utility-based search.
+	 *        use the recommended update frequency or {@code -1} to disable utility-based search
 	 */
 	public MOEAD(Problem problem, int neighborhoodSize, WeightGenerator weightGenerator, Initialization initialization,
 			Variation variation, double delta, double eta, int updateUtility) {
@@ -188,18 +191,11 @@ public class MOEAD extends AbstractAlgorithm {
 		this.neighborhoodSize = neighborhoodSize;
 		this.weightGenerator = weightGenerator;
 		this.initialization = initialization;
-		this.variation = variation;
 		this.delta = delta;
 		this.eta = eta;
 		this.updateUtility = updateUtility;
 		
-		if (variation instanceof DifferentialEvolutionVariation) {
-			useDE = true;
-		} else if (variation instanceof AbstractCompoundVariation<?>) {
-			useDE = ((AbstractCompoundVariation<?>)variation).contains(DifferentialEvolutionVariation.class);
-		} else {
-			useDE = false;
-		}
+		setVariation(variation);
 	}
 	
 	/**
@@ -218,6 +214,111 @@ public class MOEAD extends AbstractAlgorithm {
 	public MOEAD(Problem problem, int neighborhoodSize, WeightGenerator weightGenerator, Initialization initialization,
 			Variation variation, double delta, double eta) {
 		this(problem, neighborhoodSize, weightGenerator, initialization, variation, delta, eta, -1);
+	}
+
+	/**
+	 * Returns the size of the neighborhood used for mating.
+	 * 
+	 * @return the neighborhood size
+	 */
+	public int getNeighborhoodSize() {
+		return neighborhoodSize;
+	}
+
+	/**
+	 * Sets the size of the neighborhood used for mating, which must be at least {@code variation.getArity()-1}.
+	 * 
+	 * @param neighborhoodSize the neighborhood size
+	 */
+	@Property
+	public void setNeighborhoodSize(int neighborhoodSize) {
+		this.neighborhoodSize = neighborhoodSize;
+	}
+
+	/**
+	 * Returns the probability of mating with a solution in the neighborhood rather than the entire population.
+	 * 
+	 * @return the delta value
+	 */
+	public double getDelta() {
+		return delta;
+	}
+
+	/**
+	 * Sets the probability of mating with a solution in the neighborhood rather than the entire population.
+	 * 
+	 * @param delta the delta value
+	 */
+	@Property
+	public void setDelta(double delta) {
+		this.delta = delta;
+	}
+
+	/**
+	 * Returns the maximum number of population slots a solution can replace.
+	 * 
+	 * @return the eta value
+	 */
+	public double getEta() {
+		return eta;
+	}
+
+	/**
+	 * Sets the maximum number of population slots a solution can replace.
+	 * 
+	 * @param eta the eta value
+	 */
+	@Property
+	public void setEta(double eta) {
+		this.eta = eta;
+	}
+
+	/**
+	 * Returns the frequency, in generations, in which utility values are updated.
+	 * 
+	 * @return the nmber of generations between each utility update
+	 */
+	public int getUpdateUtility() {
+		return updateUtility;
+	}
+
+	/**
+	 * Sets the frequency, in generations, in which utility values are updated; set to {@code 50} to use the
+	 * recommended update frequency or {@code -1} to disable utility-based search.
+	 * 
+	 * @param updateUtility the number of generations between each utility update
+	 */
+	@Property
+	public void setUpdateUtility(int updateUtility) {
+		this.updateUtility = updateUtility;
+	}
+
+	/**
+	 * Returns the variation operator.
+	 * 
+	 * @return the variation operator
+	 */
+	public Variation getVariation() {
+		return variation;
+	}
+
+	/**
+	 * Sets the variation operator.  MOEA/D typically uses differential evolution but other variation operators
+	 * are supported.
+	 * 
+	 * @param variation the variation to set
+	 */
+	@Property("operator")
+	public void setVariation(Variation variation) {
+		this.variation = variation;
+		
+		if (variation instanceof DifferentialEvolutionVariation) {
+			useDE = true;
+		} else if (variation instanceof AbstractCompoundVariation<?>) {
+			useDE = ((AbstractCompoundVariation<?>)variation).contains(DifferentialEvolutionVariation.class);
+		} else {
+			useDE = false;
+		}
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/MSOPS.java
+++ b/src/org/moeaframework/algorithm/MSOPS.java
@@ -61,24 +61,27 @@ public class MSOPS extends AbstractEvolutionaryAlgorithm {
 	 */
 	public MSOPS(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new MSOPSRankedPopulation(generateWeights(problem, Settings.DEFAULT_POPULATION_SIZE / 2)),
 				new DifferentialEvolutionSelection(),
 				new DifferentialEvolutionVariation(),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE));
+				new RandomInitialization(problem));
 	}
 
 	/**
 	 * Constructs a new instance of the MSOPS algorithm.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population supporting MSOPS ranking
 	 * @param selection the differential evolution selection operator
 	 * @param variation the differential evolution variation operator
 	 * @param initialization the initialization method
 	 */
-	public MSOPS(Problem problem, MSOPSRankedPopulation population, DifferentialEvolutionSelection selection,
-			DifferentialEvolutionVariation variation, Initialization initialization) {
-		super(problem, population, null, initialization, variation);
+	public MSOPS(Problem problem, int initialPopulationSize, MSOPSRankedPopulation population,
+			DifferentialEvolutionSelection selection, DifferentialEvolutionVariation variation,
+			Initialization initialization) {
+		super(problem, initialPopulationSize, population, null, initialization, variation);
 		this.selection = selection;
 		
 		problem.assertType(RealVariable.class);
@@ -110,6 +113,12 @@ public class MSOPS extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(DifferentialEvolutionVariation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 	
 	@Override

--- a/src/org/moeaframework/algorithm/MSOPS.java
+++ b/src/org/moeaframework/algorithm/MSOPS.java
@@ -24,10 +24,12 @@ import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.real.DifferentialEvolutionSelection;
 import org.moeaframework.core.operator.real.DifferentialEvolutionVariation;
 import org.moeaframework.core.variable.RealVariable;
+import org.moeaframework.util.TypedProperties;
 import org.moeaframework.util.Vector;
 import org.moeaframework.util.weights.RandomGenerator;
 
@@ -105,6 +107,7 @@ public class MSOPS extends AbstractEvolutionaryAlgorithm {
 		return (DifferentialEvolutionVariation)super.getVariation();
 	}
 	
+	@Property("operator")
 	public void setVariation(DifferentialEvolutionVariation variation) {
 		super.setVariation(variation);
 	}
@@ -135,6 +138,22 @@ public class MSOPS extends AbstractEvolutionaryAlgorithm {
 		
 		population.addAll(offspring);
 		population.truncate(populationSize);
+	}
+	
+	@Override
+	public void applyConfiguration(TypedProperties properties) {
+		if (properties.contains("numberOfWeights")) {
+			setPopulation(new MSOPSRankedPopulation(generateWeights(problem, properties.getInt("numberOfWeights", 0))));
+		}
+		
+		super.applyConfiguration(properties);
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		properties.setInt("numberOfWeights", getPopulation().getNumberOfWeights());
+		return properties;
 	}
 
 }

--- a/src/org/moeaframework/algorithm/MSOPSRankedPopulation.java
+++ b/src/org/moeaframework/algorithm/MSOPSRankedPopulation.java
@@ -196,6 +196,15 @@ public class MSOPSRankedPopulation extends Population {
 	}
 	
 	/**
+	 * Returns the number of weight vectors.
+	 * 
+	 * @return the number of weight vectors
+	 */
+	public int getNumberOfWeights() {
+		return weights.size();
+	}
+	
+	/**
 	 * Returns the neighborhood of solutions nearest to and including the
 	 * given solution.
 	 * 

--- a/src/org/moeaframework/algorithm/NSGAII.java
+++ b/src/org/moeaframework/algorithm/NSGAII.java
@@ -36,6 +36,7 @@ import org.moeaframework.core.comparator.ChainedComparator;
 import org.moeaframework.core.comparator.CrowdingComparator;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.TournamentSelection;
 import org.moeaframework.core.spi.OperatorFactory;
@@ -156,6 +157,7 @@ public class NSGAII extends AbstractEvolutionaryAlgorithm implements EpsilonBoxE
 	}
 	
 	@Override
+	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
 	}

--- a/src/org/moeaframework/algorithm/NSGAII.java
+++ b/src/org/moeaframework/algorithm/NSGAII.java
@@ -70,26 +70,29 @@ public class NSGAII extends AbstractEvolutionaryAlgorithm implements EpsilonBoxE
 	 */
 	public NSGAII(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new NondominatedSortingPopulation(),
 				null,
 				new TournamentSelection(2, new ChainedComparator(new ParetoDominanceComparator(), new CrowdingComparator())),
 				OperatorFactory.getInstance().getVariation(problem),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE));
+				new RandomInitialization(problem));
 	}
 
 	/**
 	 * Constructs the NSGA-II algorithm with the specified components.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population used to store solutions
 	 * @param archive the archive used to store the result; can be {@code null}
 	 * @param selection the selection operator
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
 	 */
-	public NSGAII(Problem problem, NondominatedSortingPopulation population, EpsilonBoxDominanceArchive archive,
-			Selection selection, Variation variation, Initialization initialization) {
-		super(problem, population, archive, initialization, variation);
+	public NSGAII(Problem problem, int initialPopulationSize, NondominatedSortingPopulation population,
+			EpsilonBoxDominanceArchive archive, Selection selection, Variation variation,
+			Initialization initialization) {
+		super(problem, initialPopulationSize, population, archive, initialization, variation);
 		this.selection = selection;
 	}
 
@@ -160,6 +163,12 @@ public class NSGAII extends AbstractEvolutionaryAlgorithm implements EpsilonBoxE
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/NSGAIII.java
+++ b/src/org/moeaframework/algorithm/NSGAIII.java
@@ -53,24 +53,27 @@ public class NSGAIII extends NSGAII {
 	 */
 	public NSGAIII(Problem problem, NormalBoundaryDivisions divisions) {
 		this(problem,
+				getInitialPopulationSize(problem, divisions),
 				new ReferencePointNondominatedSortingPopulation(problem.getNumberOfObjectives(), divisions),
 				getDefaultSelection(problem),
 				getDefaultVariation(problem),
-				getDefaultInitialization(problem, divisions));
+				new RandomInitialization(problem));
 	}
 	
 	/**
 	 * Constructs a new NSGA-III instance with the specified components.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the reference point population used to store solutions
 	 * @param selection the selection operator
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
 	 */
-	public NSGAIII(Problem problem, ReferencePointNondominatedSortingPopulation population,
+	public NSGAIII(Problem problem, int initialPopulationSize, ReferencePointNondominatedSortingPopulation population,
 			Selection selection, Variation variation, Initialization initialization) {
 		super(problem,
+				initialPopulationSize,
 				population,
 				null,
 				selection,
@@ -79,18 +82,15 @@ public class NSGAIII extends NSGAII {
 	}
 	
 	/**
-	 * Returns the default initialization method that creates one population member for each reference point.
-	 * The population size is rounded up to the nearest multiple of 4.
+	 * Returns the population size, which is the number of reference points rounded up to the nearest multiple of 4.
 	 * 
 	 * @param problem the problem
 	 * @param divisions the number of divisions for generating reference points
-	 * @return the initialization method
+	 * @return the initial population size
 	 */
-	private static final Initialization getDefaultInitialization(Problem problem, NormalBoundaryDivisions divisions) {
+	private static final int getInitialPopulationSize(Problem problem, NormalBoundaryDivisions divisions) {
 		int referencePoints = divisions.getNumberOfReferencePoints(problem);
-		int populationSize = (int)Math.ceil(referencePoints / 4.0) * 4;
-		
-		return new RandomInitialization(problem, populationSize);
+		return (int)Math.ceil(referencePoints / 4.0) * 4;
 	}
 	
 	/**

--- a/src/org/moeaframework/algorithm/NSGAIII.java
+++ b/src/org/moeaframework/algorithm/NSGAIII.java
@@ -16,6 +16,7 @@ import org.moeaframework.core.operator.TournamentSelection;
 import org.moeaframework.core.operator.real.PM;
 import org.moeaframework.core.operator.real.SBX;
 import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.TypedProperties;
 import org.moeaframework.util.weights.NormalBoundaryDivisions;
 
 /**
@@ -164,6 +165,24 @@ public class NSGAIII extends NSGAII {
 	@Override
 	public ReferencePointNondominatedSortingPopulation getPopulation() {
 		return (ReferencePointNondominatedSortingPopulation)super.getPopulation();
+	}
+
+	@Override
+	public void applyConfiguration(TypedProperties properties) {
+		NormalBoundaryDivisions divisions = NormalBoundaryDivisions.tryFromProperties(properties);
+		
+		if (divisions != null) {
+			setPopulation(new ReferencePointNondominatedSortingPopulation(problem.getNumberOfObjectives(), divisions));
+		}
+		
+		super.applyConfiguration(properties);
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		properties.addAll(getPopulation().getDivisions().toProperties());
+		return properties;
 	}
 
 }

--- a/src/org/moeaframework/algorithm/PAES.java
+++ b/src/org/moeaframework/algorithm/PAES.java
@@ -24,9 +24,11 @@ import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.TypedProperties;
 
 /**
  * Implementation of the (1+1) Pareto Archived Evolution Strategy (PAES).  PAES
@@ -74,6 +76,7 @@ public class PAES extends AbstractEvolutionaryAlgorithm {
 		comparator = new ParetoDominanceComparator();
 	}
 	
+	@Property("operator")
 	public void setVariation(Mutation mutation) {
 		super.setVariation(mutation);
 	}
@@ -151,6 +154,27 @@ public class PAES extends AbstractEvolutionaryAlgorithm {
 				population.replace(0, test(parent, offspring));
 			}
 		}
+	}
+	
+	@Override
+	public void applyConfiguration(TypedProperties properties) {
+		if (properties.contains("archiveSize") || properties.contains("bisections")) {
+			int archiveSize = properties.getInt("archiveSize", getArchive().getCapacity());
+			int bisections = properties.getInt("bisections", getArchive().getBisections());
+			setArchive(new AdaptiveGridArchive(archiveSize, problem, ArithmeticUtils.pow(2, bisections)));
+		}
+		
+		super.applyConfiguration(properties);
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		
+		properties.setInt("archiveSize", getArchive().getCapacity());
+		properties.setInt("bisections", getArchive().getBisections());
+		
+		return properties;
 	}
 
 }

--- a/src/org/moeaframework/algorithm/PAES.java
+++ b/src/org/moeaframework/algorithm/PAES.java
@@ -68,9 +68,10 @@ public class PAES extends AbstractEvolutionaryAlgorithm {
 	 */
 	public PAES(Problem problem, Mutation mutation, int bisections, int archiveSize) {
 		super(problem,
+				1,
 				new Population(),
 				new AdaptiveGridArchive(archiveSize, problem, ArithmeticUtils.pow(2, bisections)),
-				null,
+				new RandomInitialization(problem),
 				mutation);
 		
 		comparator = new ParetoDominanceComparator();
@@ -91,21 +92,6 @@ public class PAES extends AbstractEvolutionaryAlgorithm {
 		return (AdaptiveGridArchive)super.getArchive();
 	}
 	
-	@Override
-	protected void initialize() {
-		// avoid calling super.initialize() since no initializer is set
-		if (initialized) {
-			throw new AlgorithmInitializationException(this, "algorithm already initialized");
-		}
-
-		initialized = true;
-		
-		Solution solution = new RandomInitialization(problem, 1).initialize()[0];
-		evaluate(solution);
-		population.add(solution);
-		archive.add(solution);
-	}
-
 	/**
 	 * The test procedure to determine which solution, the parent or offspring,
 	 * moves on to the next generation.  The solution in a lower density region

--- a/src/org/moeaframework/algorithm/PESA2.java
+++ b/src/org/moeaframework/algorithm/PESA2.java
@@ -35,8 +35,10 @@ import org.moeaframework.core.Selection;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.TypedProperties;
 
 /**
  * Implementation of the Pareto Envelope-based Selection Algorithm (PESA2).
@@ -104,6 +106,7 @@ public class PESA2 extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	@Override
+	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
 	}
@@ -154,6 +157,27 @@ public class PESA2 extends AbstractEvolutionaryAlgorithm {
 		}
 		
 		return result;
+	}
+	
+	@Override
+	public void applyConfiguration(TypedProperties properties) {
+		if (properties.contains("archiveSize") || properties.contains("bisections")) {
+			int archiveSize = properties.getInt("archiveSize", getArchive().getCapacity());
+			int bisections = properties.getInt("bisections", getArchive().getBisections());
+			setArchive(new AdaptiveGridArchive(archiveSize, problem, ArithmeticUtils.pow(2, bisections)));
+		}
+		
+		super.applyConfiguration(properties);
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		
+		properties.setInt("archiveSize", getArchive().getCapacity());
+		properties.setInt("bisections", getArchive().getBisections());
+		
+		return properties;
 	}
 	
 	/**

--- a/src/org/moeaframework/algorithm/PESA2.java
+++ b/src/org/moeaframework/algorithm/PESA2.java
@@ -74,8 +74,9 @@ public class PESA2 extends AbstractEvolutionaryAlgorithm {
 	 */
 	public PESA2(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				OperatorFactory.getInstance().getVariation(problem),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new RandomInitialization(problem),
 				8,
 				100);
 	}
@@ -84,14 +85,16 @@ public class PESA2 extends AbstractEvolutionaryAlgorithm {
 	 * Constructs a new PESA2 instance.
 	 * 
 	 * @param problem the problem
+	 * @param initialPopulationSize the initial population size
 	 * @param variation the mutation operator
 	 * @param initialization the initialization operator
 	 * @param bisections the number of bisections in the adaptive grid archive
 	 * @param archiveSize the capacity of the adaptive grid archive
 	 */
-	public PESA2(Problem problem, Variation variation,
+	public PESA2(Problem problem, int initialPopulationSize, Variation variation,
 			Initialization initialization, int bisections, int archiveSize) {
 		super(problem,
+				initialPopulationSize,
 				new Population(),
 				new AdaptiveGridArchive(archiveSize, problem, ArithmeticUtils.pow(2, bisections)),
 				initialization,
@@ -109,6 +112,12 @@ public class PESA2 extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/PeriodicAction.java
+++ b/src/org/moeaframework/algorithm/PeriodicAction.java
@@ -59,7 +59,7 @@ public abstract class PeriodicAction implements Algorithm {
 	/**
 	 * The frequency that the {@link #doAction()} method is invoked.
 	 */
-	protected final int frequency;
+	protected int frequency;
 	
 	/**
 	 * The type of frequency.

--- a/src/org/moeaframework/algorithm/RVEA.java
+++ b/src/org/moeaframework/algorithm/RVEA.java
@@ -93,9 +93,10 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	 */
 	public RVEA(Problem problem, NormalBoundaryDivisions divisions, int maxGeneration) {
 		this(problem,
+				divisions.getNumberOfReferencePoints(problem),
 				new ReferenceVectorGuidedPopulation(problem.getNumberOfObjectives(), divisions),
 				OperatorFactory.getInstance().getVariation(problem),
-				new RandomInitialization(problem, divisions.getNumberOfReferencePoints(problem)),
+				new RandomInitialization(problem),
 				maxGeneration,
 				maxGeneration / 10);
 	}
@@ -104,6 +105,7 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	 * Constructs a new instance of the RVEA algorithm.
 	 * 
 	 * @param problem the problem being solved
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population used to store solutions
 	 * @param variation the variation operator
 	 * @param initialization the initialization method
@@ -111,9 +113,9 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	 *        between convergence and diversity
 	 * @param adaptFrequency the frequency, in generations, that the reference vectors are normalized
 	 */
-	public RVEA(Problem problem, ReferenceVectorGuidedPopulation population, Variation variation,
-			Initialization initialization, int maxGeneration, int adaptFrequency) {
-		super(problem, population, null, initialization, variation);
+	public RVEA(Problem problem, int initialPopulationSize, ReferenceVectorGuidedPopulation population,
+			Variation variation, Initialization initialization, int maxGeneration, int adaptFrequency) {
+		super(problem, initialPopulationSize, population, null, initialization, variation);
 		this.maxGeneration = maxGeneration;
 		this.adaptFrequency = adaptFrequency;
 		
@@ -200,6 +202,12 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 	
 	@Override

--- a/src/org/moeaframework/algorithm/RVEA.java
+++ b/src/org/moeaframework/algorithm/RVEA.java
@@ -30,8 +30,10 @@ import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.TypedProperties;
 import org.moeaframework.util.weights.NormalBoundaryDivisions;
 
 /**
@@ -68,7 +70,7 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	/**
 	 * The frequency, in generations, that the reference vectors are normalized.
 	 */
-	private final int adaptFrequency;
+	private int adaptFrequency;
 	
 	/**
 	 * Constructs a new instance of RVEA with default settings.
@@ -77,7 +79,7 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	 * @param maxGeneration the maximum number of generations for the angle-penalized distance to transition
 	 *        between convergence and diversity
 	 */
-	public RVEA(Problem problem, int maxGeneration) {
+	public RVEA(Problem problem, int maxGeneration) { // TODO: can we remove maxGenerations?
 		this(problem, NormalBoundaryDivisions.forProblem(problem), maxGeneration);
 	}
 	
@@ -170,14 +172,67 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 		generation++;
 	}
 	
+	/**
+	 * Returns the frequency, in generations, that the reference vectors are normalized.
+	 * 
+	 * @return the frequency, in generations
+	 */
+	public int getAdaptFrequency() {
+		return adaptFrequency;
+	}
+	
+	/**
+	 * Sets the frequency, in generations, that the reference vectors are normalized.
+	 * 
+	 * @param adaptFrequency the frequency, in generations
+	 */
+	@Property
+	public void setAdaptFrequency(int adaptFrequency) {
+		this.adaptFrequency = adaptFrequency;
+	}
+	
 	@Override
 	public ReferenceVectorGuidedPopulation getPopulation() {
 		return (ReferenceVectorGuidedPopulation)super.getPopulation();
 	}
 	
 	@Override
+	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	public void applyConfiguration(TypedProperties properties) {		
+		NormalBoundaryDivisions divisions = getPopulation().getDivisions();
+		double alpha = getPopulation().getAlpha();
+		boolean changed = false;
+		
+		NormalBoundaryDivisions newDivisions = NormalBoundaryDivisions.tryFromProperties(properties);
+		
+		if (newDivisions != null) {
+			divisions = newDivisions;
+			changed = true;
+		}
+		
+		if (properties.contains("alpha")) {
+			alpha = properties.getDouble("alpha", alpha);
+			changed = true;
+		}
+		
+		if (changed) {
+			setPopulation(new ReferenceVectorGuidedPopulation(problem.getNumberOfObjectives(), divisions, alpha));
+		}
+		
+		super.applyConfiguration(properties);
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		properties.addAll(getPopulation().getDivisions().toProperties());
+		properties.setDouble("alpha", getPopulation().getAlpha());
+		return properties;
 	}
 	
 	@Override

--- a/src/org/moeaframework/algorithm/RandomSearch.java
+++ b/src/org/moeaframework/algorithm/RandomSearch.java
@@ -22,6 +22,7 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 
 /**
@@ -30,6 +31,8 @@ import org.moeaframework.core.operator.RandomInitialization;
  * solutions retained.  The result is the set of all non-dominated solutions.
  */
 public class RandomSearch extends AbstractAlgorithm {
+	
+	private int sampleSize;
 	
 	/**
 	 * The initialization routine used to generate random solutions.
@@ -48,7 +51,8 @@ public class RandomSearch extends AbstractAlgorithm {
 	 */
 	public RandomSearch(Problem problem) {
 		this(problem,
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				Settings.DEFAULT_POPULATION_SIZE,
+				new RandomInitialization(problem),
 				new NondominatedPopulation());
 	}
 
@@ -56,13 +60,36 @@ public class RandomSearch extends AbstractAlgorithm {
 	 * Constructs a new random search procedure for the given problem.
 	 * 
 	 * @param problem the problem being solved
+	 * @param sampleSize the number of solutions sampled each iteration
 	 * @param generator the initialization routine used to generate random solutions
 	 * @param archive the archive of non-dominated solutions
 	 */
-	public RandomSearch(Problem problem, Initialization generator, NondominatedPopulation archive) {
+	public RandomSearch(Problem problem, int sampleSize, Initialization generator, NondominatedPopulation archive) {
 		super(problem);
+		this.sampleSize = sampleSize;
 		this.generator = generator;
 		this.archive = archive;
+	}
+
+	/**
+	 * Returns the number of solutions sampled each iteration.
+	 * 
+	 * @return the sample size
+	 */
+	public int getSampleSize() {
+		return sampleSize;
+	}
+
+	/**
+	 * Sets the number of solutions sampled each iteration.  The main reason to set the sample size is when
+	 * distributed solution evaluations, as the sample size at least the number of threads.  The default value
+	 * is 100.
+	 * 
+	 * @param sampleSize the sample size
+	 */
+	@Property(synonym="populationSize")
+	public void setSampleSize(int sampleSize) {
+		this.sampleSize = sampleSize;
 	}
 
 	@Override
@@ -78,7 +105,7 @@ public class RandomSearch extends AbstractAlgorithm {
 
 	@Override
 	protected void iterate() {
-		Population solutions = new Population(generator.initialize());
+		Population solutions = new Population(generator.initialize(sampleSize));
 		evaluateAll(solutions);
 		archive.addAll(solutions);
 	}

--- a/src/org/moeaframework/algorithm/ReferencePointNondominatedSortingPopulation.java
+++ b/src/org/moeaframework/algorithm/ReferencePointNondominatedSortingPopulation.java
@@ -168,6 +168,15 @@ public class ReferencePointNondominatedSortingPopulation extends NondominatedSor
 	}
 	
 	/**
+	 * Returns the number of divisions used to create the reference points.
+	 * 
+	 * @return the divisions object
+	 */
+	public NormalBoundaryDivisions getDivisions() {
+		return divisions;
+	}
+	
+	/**
 	 * Initializes the ideal point and reference points (weights).
 	 */
 	private void initialize() {

--- a/src/org/moeaframework/algorithm/ReferencePointNondominatedSortingPopulation.java
+++ b/src/org/moeaframework/algorithm/ReferencePointNondominatedSortingPopulation.java
@@ -102,8 +102,7 @@ public class ReferencePointNondominatedSortingPopulation extends NondominatedSor
 	 * @param numberOfObjectives the number of objectives
 	 * @param divisions the number of divisions
 	 */
-	public ReferencePointNondominatedSortingPopulation(int numberOfObjectives,
-			NormalBoundaryDivisions divisions) {
+	public ReferencePointNondominatedSortingPopulation(int numberOfObjectives,NormalBoundaryDivisions divisions) {
 		super();
 		this.numberOfObjectives = numberOfObjectives;
 		this.divisions = divisions;

--- a/src/org/moeaframework/algorithm/ReferenceVectorGuidedPopulation.java
+++ b/src/org/moeaframework/algorithm/ReferenceVectorGuidedPopulation.java
@@ -135,6 +135,25 @@ public class ReferenceVectorGuidedPopulation extends Population {
 	}
 	
 	/**
+	 * Returns the number of divisions used to generate the reference vectors.
+	 * 
+	 * @return the number of divisions
+	 */
+	public NormalBoundaryDivisions getDivisions() {
+		return divisions;
+	}
+	
+	/**
+	 * Returns the {@code alpha} parameter, which controls the rate of change in the angle-penalized
+	 * distance function.
+	 * 
+	 * @return the {@code alpha} parameter value
+	 */
+	public double getAlpha() {
+		return alpha;
+	}
+	
+	/**
 	 * Scaling factor used in the angle-penalized distance function.  This
 	 * should be set to {@code currentGeneration / maxGenerations}.  Smaller
 	 * values favor convergence while larger values favor diversity.

--- a/src/org/moeaframework/algorithm/SMSEMOA.java
+++ b/src/org/moeaframework/algorithm/SMSEMOA.java
@@ -73,7 +73,8 @@ public class SMSEMOA extends AbstractEvolutionaryAlgorithm {
 	 */
 	public SMSEMOA(Problem problem) {
 		this(problem,
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				Settings.DEFAULT_POPULATION_SIZE,
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getVariation(problem),
 				new HypervolumeContributionFitnessEvaluator(problem));
 	}
@@ -82,13 +83,14 @@ public class SMSEMOA extends AbstractEvolutionaryAlgorithm {
 	 * Constructs a new SMS-EMOA instance.
 	 * 
 	 * @param problem the problem
+	 * @param initialPopulationSize the initial population size
 	 * @param initialization the initialization operator
 	 * @param variation the variation operator
 	 * @param fitnessEvaluator the fitness evaluator
 	 */
-	public SMSEMOA(Problem problem, Initialization initialization,
+	public SMSEMOA(Problem problem, int initialPopulationSize, Initialization initialization,
 			Variation variation, FitnessEvaluator fitnessEvaluator) {
-		super(problem, new Population(), null, initialization, variation);
+		super(problem, initialPopulationSize, new Population(), null, initialization, variation);
 		this.fitnessEvaluator = fitnessEvaluator;
 		
 		if (fitnessEvaluator ==  null) {
@@ -102,6 +104,12 @@ public class SMSEMOA extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/SPEA2.java
+++ b/src/org/moeaframework/algorithm/SPEA2.java
@@ -37,6 +37,8 @@ import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.FitnessComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.configuration.Configurable;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.indicator.IndicatorUtils;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.TournamentSelection;
@@ -74,12 +76,12 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	/**
 	 * The number of offspring.
 	 */
-	private final int numberOfOffspring;
+	private int numberOfOffspring;
 	
 	/**
 	 * Strength-based fitness evaluator.
 	 */
-	protected final StrengthFitnessEvaluator fitnessEvaluator;
+	protected StrengthFitnessEvaluator fitnessEvaluator;
 	
 	/**
 	 * Compares solutions based on strength.
@@ -120,8 +122,22 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	@Override
+	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	public int getNumberOfOffspring() {
+		return numberOfOffspring;
+	}
+	
+	@Property("offspringSize")
+	public void setNumberOfOffspring(int numberOfOffspring) {
+		this.numberOfOffspring = numberOfOffspring;
+	}
+	
+	public StrengthFitnessEvaluator getFitnessEvaluator() {
+		return fitnessEvaluator;
 	}
 
 	@Override
@@ -347,13 +363,12 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	/**
 	 * Fitness evaluator for the strength measure with crowding-based niching.
 	 */
-	public class StrengthFitnessEvaluator implements FitnessEvaluator {
+	public class StrengthFitnessEvaluator implements FitnessEvaluator, Configurable {
 		
 		/**
-		 * Crowding is based on the distance to the {@code k}-th nearest
-		 * neighbor.
+		 * Crowding is based on the distance to the {@code k}-th nearest neighbor.
 		 */
-		private final int k;
+		private int k;
 		
 		/**
 		 * Pareto dominance comparator.
@@ -364,14 +379,22 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 		 * Constructs a new fitness evaluator for computing the strength
 		 * measure with crowding-based niching.
 		 * 
-		 * @param k crowding is based on the distance to the {@code k}-th
-		 *        nearest neighbor
+		 * @param k crowding is based on the distance to the {@code k}-th nearest neighbor
 		 */
 		public StrengthFitnessEvaluator(int k) {
 			super();
 			this.k = k;
 			
 			comparator = new ParetoDominanceComparator();
+		}
+		
+		public int getK() {
+			return k;
+		}
+		
+		@Property
+		public void setK(int k) {
+			this.k = k;
 		}
 
 		@Override

--- a/src/org/moeaframework/algorithm/SPEA2.java
+++ b/src/org/moeaframework/algorithm/SPEA2.java
@@ -95,7 +95,8 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	 */
 	public SPEA2(Problem problem) {
 		this(problem,
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				Settings.DEFAULT_POPULATION_SIZE,
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getVariation(problem),
 				Settings.DEFAULT_POPULATION_SIZE,
 				1);
@@ -105,15 +106,16 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	 * Constructs a new instance of SPEA2.
 	 * 
 	 * @param problem the problem
+	 * @param initialPopulationSize the initial population size
 	 * @param initialization the initialization procedure
 	 * @param variation the variation operator
 	 * @param numberOfOffspring the number of offspring generated each iteration
 	 * @param k niching parameter specifying that crowding is computed using
 	 *        the {@code k}-th nearest neighbor, recommend {@code k=1}
 	 */
-	public SPEA2(Problem problem, Initialization initialization,
+	public SPEA2(Problem problem, int initialPopulationSize, Initialization initialization,
 			Variation variation, int numberOfOffspring, int k) {
-		super(problem, new Population(), null, initialization, variation);
+		super(problem, initialPopulationSize, new Population(), null, initialization, variation);
 		this.numberOfOffspring = numberOfOffspring;
 		
 		fitnessEvaluator = new StrengthFitnessEvaluator(k);
@@ -125,6 +127,12 @@ public class SPEA2 extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 	
 	public int getNumberOfOffspring() {

--- a/src/org/moeaframework/algorithm/VEGA.java
+++ b/src/org/moeaframework/algorithm/VEGA.java
@@ -67,9 +67,10 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 	 */
 	public VEGA(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new Population(),
 				null,
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getVariation(problem));
 	}
 
@@ -77,15 +78,16 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 	 * Constructs a new VEGA instance.
 	 * 
 	 * @param problem the problem
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population
 	 * @param archive the external archive; or {@code null} if no external archive is used
 	 * @param initialization the initialization operator
 	 * @param variation the variation operator
 	 */
-	public VEGA(Problem problem, Population population,
+	public VEGA(Problem problem, int initialPopulationSize, Population population,
 			NondominatedPopulation archive, Initialization initialization,
 			Variation variation) {
-		super(problem, population, archive, initialization, variation);		
+		super(problem, initialPopulationSize, population, archive, initialization, variation);		
 		selection = new VEGASelection();
 	}
 	
@@ -93,6 +95,12 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/VEGA.java
+++ b/src/org/moeaframework/algorithm/VEGA.java
@@ -27,6 +27,7 @@ import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.ObjectiveComparator;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.TournamentSelection;
 import org.moeaframework.core.spi.OperatorFactory;
@@ -89,6 +90,7 @@ public class VEGA extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	@Override
+	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
 	}

--- a/src/org/moeaframework/algorithm/pisa/PISAAlgorithm.java
+++ b/src/org/moeaframework/algorithm/pisa/PISAAlgorithm.java
@@ -327,8 +327,8 @@ public class PISAAlgorithm extends AbstractAlgorithm {
 	 * @throws IOException if an I/O error occurred
 	 */
 	private void state0() throws IOException {
-		Initialization initialization = new RandomInitialization(problem, alpha);
-		Solution[] initialPopulation = initialization.initialize();
+		Initialization initialization = new RandomInitialization(problem);
+		Solution[] initialPopulation = initialization.initialize(alpha);
 		int[] initialIds = new int[alpha];
 
 		evaluateAll(initialPopulation);

--- a/src/org/moeaframework/algorithm/pso/AbstractPSOAlgorithm.java
+++ b/src/org/moeaframework/algorithm/pso/AbstractPSOAlgorithm.java
@@ -29,6 +29,8 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.DominanceComparator;
+import org.moeaframework.core.configuration.Configurable;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.fitness.FitnessBasedArchive;
 import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.operator.RandomInitialization;
@@ -38,7 +40,7 @@ import org.moeaframework.core.variable.RealVariable;
 /**
  * Abstract multi-objective particle swarm optimizer (MOPSO).
  */
-public abstract class AbstractPSOAlgorithm extends AbstractAlgorithm {
+public abstract class AbstractPSOAlgorithm extends AbstractAlgorithm implements Configurable {
 	
 	/**
 	 * The number of particles.
@@ -118,12 +120,79 @@ public abstract class AbstractPSOAlgorithm extends AbstractAlgorithm {
 		this.leaders = leaders;
 		this.archive = archive;
 		this.mutation = mutation;
-
-		particles = new Solution[swarmSize];
-		localBestParticles = new Solution[swarmSize];
-		velocities = new double[swarmSize][problem.getNumberOfVariables()];
 	}
 	
+	/**
+	 * Returns the number of particles (aka swarm size or population size).
+	 * 
+	 * @return the swarm size
+	 */
+	public int getSwarmSize() {
+		return swarmSize;
+	}
+
+	/**
+	 * Sets the number of particles (aka swarm size or population size).  This value can only be set before
+	 * initialization.
+	 * 
+	 * @param swarmSize the swarm size
+	 */
+	@Property(synonym="populationSize")
+	public void setSwarmSize(int swarmSize) {
+		assertNotInitialized();
+		this.swarmSize = swarmSize;
+	}
+
+	/**
+	 * Returns the number of leaders, which tracks the best particles according to some fitness criteria.
+	 * 
+	 * @return the leader size
+	 */
+	public int getLeaderSize() {
+		return leaderSize;
+	}
+
+	/**
+	 * Sets the number of leaders, which tracks the best particles according to some fitness criteria.  This value
+	 * can only be set before initialization.
+	 * 
+	 * @param leader the leader size
+	 */
+	@Property(synonym="archiveSize")
+	public void setLeaderSize(int leaderSize) {
+		assertNotInitialized();
+		this.leaderSize = leaderSize;
+	}
+	
+	/**
+	 * Returns the mutation operator, or {@code null} if no mutation is defined.
+	 * 
+	 * @return the mutation operator or {@code null}
+	 */
+	public Mutation getMutation() {
+		return mutation;
+	}
+	
+	/**
+	 * Returns the archive of non-dominated solutions; or {@code null} of no external archive is used.
+	 * 
+	 * @return the archive or {@code null}
+	 */
+	protected NondominatedPopulation getArchive() {
+		return archive;
+	}
+	
+	/**
+	 * Sets the archive of non-dominated solutions; or {@code null} of no external archive is used.  This value
+	 * can only be set before initialization.
+	 * 
+	 * @param archive the archive or {@code null}.
+	 */
+	protected void setArchive(NondominatedPopulation archive) {
+		assertNotInitialized();
+		this.archive = archive;
+	}
+
 	/**
 	 * Update the speeds of all particles.
 	 */
@@ -264,8 +333,11 @@ public abstract class AbstractPSOAlgorithm extends AbstractAlgorithm {
 		super.initialize();
 		
 		Solution[] initialParticles = new RandomInitialization(problem, swarmSize).initialize();
-		
 		evaluateAll(initialParticles);
+		
+		particles = new Solution[swarmSize];
+		localBestParticles = new Solution[swarmSize];
+		velocities = new double[swarmSize][problem.getNumberOfVariables()];
 		
 		for (int i = 0; i < swarmSize; i++) {
 			particles[i] = initialParticles[i];

--- a/src/org/moeaframework/algorithm/pso/AbstractPSOAlgorithm.java
+++ b/src/org/moeaframework/algorithm/pso/AbstractPSOAlgorithm.java
@@ -332,7 +332,7 @@ public abstract class AbstractPSOAlgorithm extends AbstractAlgorithm implements 
 	protected void initialize() {
 		super.initialize();
 		
-		Solution[] initialParticles = new RandomInitialization(problem, swarmSize).initialize();
+		Solution[] initialParticles = new RandomInitialization(problem).initialize(swarmSize);
 		evaluateAll(initialParticles);
 		
 		particles = new Solution[swarmSize];
@@ -401,7 +401,7 @@ public abstract class AbstractPSOAlgorithm extends AbstractAlgorithm implements 
 		if (!isInitialized()) {
 			throw new AlgorithmInitializationException(this, "algorithm not initialized");
 		}
-
+		
 		List<Solution> particlesList = copyToList(particles);
 		List<Solution> localBestParticlesList = copyToList(localBestParticles);
 		List<Solution> leadersList = leaders.asList(true);
@@ -421,8 +421,11 @@ public abstract class AbstractPSOAlgorithm extends AbstractAlgorithm implements 
 		super.initialize();
 
 		PSOAlgorithmState state = (PSOAlgorithmState)objState;
-
+		
 		numberOfEvaluations = state.getNumberOfEvaluations();
+		particles = new Solution[swarmSize];
+		localBestParticles = new Solution[swarmSize];
+		velocities = new double[swarmSize][problem.getNumberOfVariables()];
 		
 		if (state.getParticles().size() != swarmSize) {
 			throw new NotSerializableException("swarmSize does not match serialized state");

--- a/src/org/moeaframework/algorithm/pso/SMPSO.java
+++ b/src/org/moeaframework/algorithm/pso/SMPSO.java
@@ -29,9 +29,6 @@ import org.moeaframework.core.operator.real.PM;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
 
-//NOTE: This implementation is derived from the original manuscripts and the
-//JMetal implementation.
-
 /**
  * Implementation of SMPSO, the speed-constrained multi-objective particle
  * swarm optimizer.

--- a/src/org/moeaframework/algorithm/sa/AMOSA.java
+++ b/src/org/moeaframework/algorithm/sa/AMOSA.java
@@ -55,6 +55,7 @@ public class AMOSA extends AbstractSimulatedAnnealingAlgorithm {
 	protected final Initialization initialization;
 	protected Mutation mutation;
 	
+	protected final double gamma;
 	protected final int softLimit;
 	protected final int hardLimit;
 	
@@ -67,8 +68,9 @@ public class AMOSA extends AbstractSimulatedAnnealingAlgorithm {
 	
 	public AMOSA(Problem problem) {
 		this(problem,
-				new RandomInitialization(problem, 2 * Settings.DEFAULT_POPULATION_SIZE), // gamma * softLimit
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getMutation(problem),
+				2.0, // gamma
 				Settings.DEFAULT_POPULATION_SIZE, // softLimit
 				10, // hardLimit
 				0.0000001, // tMin
@@ -78,12 +80,13 @@ public class AMOSA extends AbstractSimulatedAnnealingAlgorithm {
 				20); //numberOfHillClimbingIterationsForRefinement
 	}
 	
-	public AMOSA(Problem problem, Initialization initialization, Mutation mutation, int softLimit, int hardLimit,
-			double tMin, double tMax, double alpha, int numberOfIterationsPerTemperature,
+	public AMOSA(Problem problem, Initialization initialization, Mutation mutation, double gamma, int softLimit,
+			int hardLimit, double tMin, double tMax, double alpha, int numberOfIterationsPerTemperature,
 			int numberOfHillClimbingIterationsForRefinement) {
 		super(problem,tMin,tMax);
 		this.initialization = initialization;
 		this.mutation = mutation;
+		this.gamma = gamma;
 		this.softLimit = softLimit;
 		this.hardLimit = hardLimit;
 		this.alpha = alpha;
@@ -96,7 +99,7 @@ public class AMOSA extends AbstractSimulatedAnnealingAlgorithm {
 	public void initialize() {
 		super.initialize();
 
-		Solution[] initialSolutions = initialization.initialize();
+		Solution[] initialSolutions = initialization.initialize((int)(gamma * softLimit));
 		evaluateAll(initialSolutions);
 
 		//refine all initial solutions and add into pareto set: archive
@@ -110,7 +113,6 @@ public class AMOSA extends AbstractSimulatedAnnealingAlgorithm {
 				if (paretoDominanceComparator.compare(initialSolutions[i], child) > 0) {
 					initialSolutions[i] = child;
 				}
-				
 			}
 			
 			archive.add(initialSolutions[i]);

--- a/src/org/moeaframework/algorithm/sa/AMOSA.java
+++ b/src/org/moeaframework/algorithm/sa/AMOSA.java
@@ -31,6 +31,7 @@ import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.comparator.DominanceComparator;
 import org.moeaframework.core.comparator.ParetoDominanceComparator;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.spi.OperatorFactory;
@@ -346,6 +347,7 @@ public class AMOSA extends AbstractSimulatedAnnealingAlgorithm {
 		return mutation;
 	}
 	
+	@Property("operator")
 	public void setVariation(Mutation mutation) {
 		this.mutation = mutation;
 	}

--- a/src/org/moeaframework/algorithm/single/AggregateObjectiveComparator.java
+++ b/src/org/moeaframework/algorithm/single/AggregateObjectiveComparator.java
@@ -42,5 +42,12 @@ import org.moeaframework.core.comparator.DominanceComparator;
  * to invoke the {@code compare} method and avoid the compilation error.
  */
 public interface AggregateObjectiveComparator extends DominanceComparator, Comparator<Solution> {
+	
+	/**
+	 * Returns the weights used by this linear aggregate function.
+	 * 
+	 * @return the weights
+	 */
+	public double[] getWeights();
 
 }

--- a/src/org/moeaframework/algorithm/single/DifferentialEvolution.java
+++ b/src/org/moeaframework/algorithm/single/DifferentialEvolution.java
@@ -53,8 +53,9 @@ public class DifferentialEvolution extends SingleObjectiveEvolutionaryAlgorithm 
 	 */
 	public DifferentialEvolution(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new LinearDominanceComparator(),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new RandomInitialization(problem),
 				new DifferentialEvolutionSelection(),
 				new DifferentialEvolutionVariation());
 	}
@@ -63,15 +64,16 @@ public class DifferentialEvolution extends SingleObjectiveEvolutionaryAlgorithm 
 	 * Constructs a new instance of the single-objective differential evolution (DE) algorithm.
 	 * 
 	 * @param problem the problem
+	 * @param initialPopulationSize the initial population size
 	 * @param comparator the aggregate objective comparator
 	 * @param initialization the initialization method
 	 * @param selection the differential evolution selection operator
 	 * @param variation the differential evolution variation operator
 	 */
-	public DifferentialEvolution(Problem problem, AggregateObjectiveComparator comparator,
+	public DifferentialEvolution(Problem problem, int initialPopulationSize, AggregateObjectiveComparator comparator,
 			Initialization initialization, DifferentialEvolutionSelection selection,
 			DifferentialEvolutionVariation variation) {
-		super(problem, new Population(), null, comparator, initialization, variation);
+		super(problem, initialPopulationSize, new Population(), null, comparator, initialization, variation);
 		this.selection = selection;
 		
 		problem.assertType(RealVariable.class);

--- a/src/org/moeaframework/algorithm/single/DifferentialEvolution.java
+++ b/src/org/moeaframework/algorithm/single/DifferentialEvolution.java
@@ -17,7 +17,6 @@
  */
 package org.moeaframework.algorithm.single;
 
-import org.moeaframework.algorithm.AbstractEvolutionaryAlgorithm;
 import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
@@ -40,12 +39,7 @@ import org.moeaframework.core.variable.RealVariable;
  *       Journal of Global Optimization, 11(4):341-359, 1997.
  * </ol>
  */
-public class DifferentialEvolution extends AbstractEvolutionaryAlgorithm {
-	
-	/**
-	 * The aggregate objective comparator.
-	 */
-	private final AggregateObjectiveComparator comparator;
+public class DifferentialEvolution extends SingleObjectiveEvolutionaryAlgorithm {
 	
 	/**
 	 * The differential evolution selection operator.
@@ -74,10 +68,10 @@ public class DifferentialEvolution extends AbstractEvolutionaryAlgorithm {
 	 * @param selection the differential evolution selection operator
 	 * @param variation the differential evolution variation operator
 	 */
-	public DifferentialEvolution(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
-			DifferentialEvolutionSelection selection, DifferentialEvolutionVariation variation) {
-		super(problem, new Population(), null, initialization, variation);
-		this.comparator = comparator;
+	public DifferentialEvolution(Problem problem, AggregateObjectiveComparator comparator,
+			Initialization initialization, DifferentialEvolutionSelection selection,
+			DifferentialEvolutionVariation variation) {
+		super(problem, new Population(), null, comparator, initialization, variation);
 		this.selection = selection;
 		
 		problem.assertType(RealVariable.class);

--- a/src/org/moeaframework/algorithm/single/EvolutionStrategy.java
+++ b/src/org/moeaframework/algorithm/single/EvolutionStrategy.java
@@ -17,13 +17,12 @@
  */
 package org.moeaframework.algorithm.single;
 
-import org.moeaframework.algorithm.AbstractEvolutionaryAlgorithm;
 import org.moeaframework.core.Initialization;
-import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.variable.RealVariable;
 
@@ -41,13 +40,13 @@ import org.moeaframework.core.variable.RealVariable;
  *       Fromman-Holzboog, 1971.
  * </ol>
  */
-public class EvolutionStrategy extends AbstractEvolutionaryAlgorithm {
-	
+public class EvolutionStrategy extends SingleObjectiveEvolutionaryAlgorithm {
+
 	/**
-	 * The aggregate objective comparator.
+	 * Constructs a new instance of the evolution strategy (ES) algorithm with default settings.
+	 * 
+	 * @param problem the problem to solve
 	 */
-	private final AggregateObjectiveComparator comparator;
-	
 	public EvolutionStrategy(Problem problem) {
 		this(problem,
 				new LinearDominanceComparator(),
@@ -58,15 +57,14 @@ public class EvolutionStrategy extends AbstractEvolutionaryAlgorithm {
 	/**
 	 * Constructs a new instance of the evolution strategy (ES) algorithm.
 	 * 
-	 * @param problem the problem
+	 * @param problem the problem to solve
 	 * @param comparator the aggregate objective comparator
 	 * @param initialization the initialization method
 	 * @param mutation the mutation operator
 	 */
 	public EvolutionStrategy(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
 			SelfAdaptiveNormalVariation variation) {
-		super(problem, new Population(), null, initialization, variation);
-		this.comparator = comparator;
+		super(problem, new Population(), null, comparator, initialization, variation);
 		
 		problem.assertType(RealVariable.class);
 	}
@@ -91,17 +89,11 @@ public class EvolutionStrategy extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	@Override
-	public NondominatedPopulation getResult() {
-		NondominatedPopulation result = new NondominatedPopulation(comparator);
-		result.addAll(getPopulation());
-		return result;
-	}
-	
-	@Override
 	public SelfAdaptiveNormalVariation getVariation() {
 		return (SelfAdaptiveNormalVariation)super.getVariation();
 	}
 	
+	@Property("operator")
 	public void setVariation(SelfAdaptiveNormalVariation variation) {
 		super.setVariation(variation);
 	}

--- a/src/org/moeaframework/algorithm/single/EvolutionStrategy.java
+++ b/src/org/moeaframework/algorithm/single/EvolutionStrategy.java
@@ -49,8 +49,9 @@ public class EvolutionStrategy extends SingleObjectiveEvolutionaryAlgorithm {
 	 */
 	public EvolutionStrategy(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new LinearDominanceComparator(),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new RandomInitialization(problem),
 				new SelfAdaptiveNormalVariation());
 	}
 
@@ -58,13 +59,14 @@ public class EvolutionStrategy extends SingleObjectiveEvolutionaryAlgorithm {
 	 * Constructs a new instance of the evolution strategy (ES) algorithm.
 	 * 
 	 * @param problem the problem to solve
+	 * @param initialPopulationSize the initial population size
 	 * @param comparator the aggregate objective comparator
 	 * @param initialization the initialization method
 	 * @param mutation the mutation operator
 	 */
-	public EvolutionStrategy(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
-			SelfAdaptiveNormalVariation variation) {
-		super(problem, new Population(), null, comparator, initialization, variation);
+	public EvolutionStrategy(Problem problem, int initialPopulationSize, AggregateObjectiveComparator comparator,
+			Initialization initialization, SelfAdaptiveNormalVariation variation) {
+		super(problem, initialPopulationSize, new Population(), null, comparator, initialization, variation);
 		
 		problem.assertType(RealVariable.class);
 	}

--- a/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
+++ b/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
@@ -20,7 +20,6 @@ package org.moeaframework.algorithm.single;
 import java.io.NotSerializableException;
 import java.util.Comparator;
 
-import org.moeaframework.algorithm.AbstractEvolutionaryAlgorithm;
 import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Population;
@@ -29,6 +28,7 @@ import org.moeaframework.core.Selection;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.RandomInitialization;
 import org.moeaframework.core.operator.TournamentSelection;
 import org.moeaframework.core.spi.OperatorFactory;
@@ -43,13 +43,8 @@ import org.moeaframework.core.spi.OperatorFactory;
  *       MIT Press, ISBN: 9780262082136.
  * </ol>
  */
-public class GeneticAlgorithm extends AbstractEvolutionaryAlgorithm {
+public class GeneticAlgorithm extends SingleObjectiveEvolutionaryAlgorithm {
 	
-	/**
-	 * The aggregate objective comparator.
-	 */
-	private final AggregateObjectiveComparator comparator;
-
 	/**
 	 * The selection operator.
 	 */
@@ -89,8 +84,7 @@ public class GeneticAlgorithm extends AbstractEvolutionaryAlgorithm {
 	 */
 	public GeneticAlgorithm(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
 			Selection selection, Variation variation) {
-		super(problem, new Population(), null, initialization, variation);
-		this.comparator = comparator;
+		super(problem, new Population(), null, comparator, initialization, variation);
 		this.selection = selection;
 	}
 
@@ -148,6 +142,7 @@ public class GeneticAlgorithm extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	@Override
+	@Property("operator")
 	public void setVariation(Variation variation) {
 		super.setVariation(variation);
 	}

--- a/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
+++ b/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
@@ -62,36 +62,39 @@ public class GeneticAlgorithm extends SingleObjectiveEvolutionaryAlgorithm {
 	 */
 	public GeneticAlgorithm(Problem problem) {
 		this(problem,
+				Settings.DEFAULT_POPULATION_SIZE,
 				new LinearDominanceComparator(),
-				new RandomInitialization(problem, Settings.DEFAULT_POPULATION_SIZE),
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getVariation(problem));
 	}
 	
 	// Internal constructor to ensure tournament selection uses provided comparator
-	private GeneticAlgorithm(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
-			Variation variation) {
-		this(problem, comparator, initialization, new TournamentSelection(2, comparator), variation);
+	private GeneticAlgorithm(Problem problem, int initialPopulationSize, AggregateObjectiveComparator comparator,
+			Initialization initialization, Variation variation) {
+		this(problem, initialPopulationSize, comparator, initialization, new TournamentSelection(2, comparator),
+				variation);
 	}
 
 	/**
 	 * Constructs a new instance of the genetic algorithm (GA).
 	 * 
 	 * @param problem the problem
+	 * @param initialPopulationSize the initial population size
 	 * @param comparator the aggregate objective comparator
 	 * @param initialization the initialization method
 	 * @param selection the selection operator
 	 * @param variation the variation operator
 	 */
-	public GeneticAlgorithm(Problem problem, AggregateObjectiveComparator comparator, Initialization initialization,
-			Selection selection, Variation variation) {
-		super(problem, new Population(), null, comparator, initialization, variation);
+	public GeneticAlgorithm(Problem problem, int initialPopulationSize, AggregateObjectiveComparator comparator,
+			Initialization initialization, Selection selection, Variation variation) {
+		super(problem, initialPopulationSize, new Population(), null, comparator, initialization, variation);
 		this.selection = selection;
 	}
 
 	@Override
 	protected void initialize() {
 		super.initialize();
-		
+
 		eliteSolution = getPopulation().get(0);
 		updateEliteSolution();
 	}

--- a/src/org/moeaframework/algorithm/single/LinearDominanceComparator.java
+++ b/src/org/moeaframework/algorithm/single/LinearDominanceComparator.java
@@ -52,5 +52,10 @@ AggregateObjectiveComparator, Serializable {
 	public LinearDominanceComparator(double... weights) {
 		super(new AggregateConstraintComparator(), new LinearObjectiveComparator(weights));
 	}
+	
+	@Override
+	public double[] getWeights() {
+		return ((LinearObjectiveComparator)comparators[1]).getWeights();
+	}
 
 }

--- a/src/org/moeaframework/algorithm/single/LinearObjectiveComparator.java
+++ b/src/org/moeaframework/algorithm/single/LinearObjectiveComparator.java
@@ -57,6 +57,11 @@ public class LinearObjectiveComparator implements AggregateObjectiveComparator, 
 			this.weights = new double[] { 1.0 };
 		}
 	}
+	
+	@Override
+	public double[] getWeights() {
+		return weights;
+	}
 
 	@Override
 	public int compare(Solution solution1, Solution solution2) {

--- a/src/org/moeaframework/algorithm/single/MinMaxDominanceComparator.java
+++ b/src/org/moeaframework/algorithm/single/MinMaxDominanceComparator.java
@@ -52,5 +52,10 @@ AggregateObjectiveComparator, Serializable {
 	public MinMaxDominanceComparator(double... weights) {
 		super(new AggregateConstraintComparator(), new MinMaxObjectiveComparator(weights));
 	}
+	
+	@Override
+	public double[] getWeights() {
+		return ((MinMaxObjectiveComparator)comparators[1]).getWeights();
+	}
 
 }

--- a/src/org/moeaframework/algorithm/single/MinMaxObjectiveComparator.java
+++ b/src/org/moeaframework/algorithm/single/MinMaxObjectiveComparator.java
@@ -59,6 +59,11 @@ public class MinMaxObjectiveComparator implements AggregateObjectiveComparator, 
 			this.weights = new double[] { 1.0 };
 		}
 	}
+	
+	@Override
+	public double[] getWeights() {
+		return weights;
+	}
 
 	@Override
 	public int compare(Solution solution1, Solution solution2) {

--- a/src/org/moeaframework/algorithm/single/SingleObjectiveEvolutionaryAlgorithm.java
+++ b/src/org/moeaframework/algorithm/single/SingleObjectiveEvolutionaryAlgorithm.java
@@ -24,6 +24,7 @@ import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.configuration.ConfigurationException;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.util.TypedProperties;
 
 /**
@@ -41,15 +42,17 @@ public abstract class SingleObjectiveEvolutionaryAlgorithm extends AbstractEvolu
 	 * Constructs a new single-objective algorithm.
 	 * 
 	 * @param problem the problem to solve
+	 * @param initialPopulationSize the initial population size
 	 * @param population the population
 	 * @param archive the archive storing the non-dominated solutions
 	 * @param comparator the aggregate objective comparator
 	 * @param initialization the initialization method
 	 * @param variation the variation operator
 	 */
-	public SingleObjectiveEvolutionaryAlgorithm(Problem problem, Population population, NondominatedPopulation archive,
-			AggregateObjectiveComparator comparator, Initialization initialization, Variation variation) {
-		super(problem, population, archive, initialization, variation);
+	public SingleObjectiveEvolutionaryAlgorithm(Problem problem, int initialPopulationSize, Population population,
+			NondominatedPopulation archive, AggregateObjectiveComparator comparator, Initialization initialization,
+			Variation variation) {
+		super(problem, initialPopulationSize, population, archive, initialization, variation);
 		this.comparator = comparator;
 	}
 	
@@ -76,6 +79,12 @@ public abstract class SingleObjectiveEvolutionaryAlgorithm extends AbstractEvolu
 	 */
 	public void setComparator(AggregateObjectiveComparator comparator) {
 		this.comparator = comparator;
+	}
+	
+	@Override
+	@Property("populationSize")
+	public void setInitialPopulationSize(int initialPopulationSize) {
+		super.setInitialPopulationSize(initialPopulationSize);
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/single/SingleObjectiveEvolutionaryAlgorithm.java
+++ b/src/org/moeaframework/algorithm/single/SingleObjectiveEvolutionaryAlgorithm.java
@@ -1,0 +1,115 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.algorithm.single;
+
+import org.moeaframework.algorithm.AbstractEvolutionaryAlgorithm;
+import org.moeaframework.core.Initialization;
+import org.moeaframework.core.NondominatedPopulation;
+import org.moeaframework.core.Population;
+import org.moeaframework.core.Problem;
+import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.ConfigurationException;
+import org.moeaframework.util.TypedProperties;
+
+/**
+ * Abstract class for building single-objective evolutionary algorithms.  These use an aggregating
+ * or scalarizing function that converts multiple objective values into a single fitness value.
+ */
+public abstract class SingleObjectiveEvolutionaryAlgorithm extends AbstractEvolutionaryAlgorithm {
+	
+	/**
+	 * The aggregate objective comparator.
+	 */
+	protected AggregateObjectiveComparator comparator;
+
+	/**
+	 * Constructs a new single-objective algorithm.
+	 * 
+	 * @param problem the problem to solve
+	 * @param population the population
+	 * @param archive the archive storing the non-dominated solutions
+	 * @param comparator the aggregate objective comparator
+	 * @param initialization the initialization method
+	 * @param variation the variation operator
+	 */
+	public SingleObjectiveEvolutionaryAlgorithm(Problem problem, Population population, NondominatedPopulation archive,
+			AggregateObjectiveComparator comparator, Initialization initialization, Variation variation) {
+		super(problem, population, archive, initialization, variation);
+		this.comparator = comparator;
+	}
+	
+	@Override
+	public NondominatedPopulation getResult() {
+		NondominatedPopulation result = new NondominatedPopulation(comparator);
+		result.addAll(getPopulation());
+		return result;
+	}
+	
+	/**
+	 * Returns the aggregate objective comparator that scalarizes multiple objectives into a single fitness value.
+	 * 
+	 * @return the aggregate objective comparator
+	 */
+	public AggregateObjectiveComparator getComparator() {
+		return comparator;
+	}
+
+	/**
+	 * Sets the aggregate objective comparator that scalarizes multiple objectives into a single fitness value.
+	 * 
+	 * @param comparator the aggregate objective comparator
+	 */
+	public void setComparator(AggregateObjectiveComparator comparator) {
+		this.comparator = comparator;
+	}
+
+	@Override
+	public void applyConfiguration(TypedProperties properties) {
+		if (properties.contains("method") || properties.contains("weights")) {
+			String method = properties.getString("method", "linear");
+			double[] weights = properties.getDoubleArray("weights", new double[] { 1.0 });
+
+			if (method.equalsIgnoreCase("linear")) {
+				setComparator(new LinearDominanceComparator(weights));
+			} else if (method.equalsIgnoreCase("min-max")) {
+				setComparator(new MinMaxDominanceComparator(weights));
+			} else {
+				throw new ConfigurationException("unrecognized weighting method: " + method);
+			}
+		}
+		
+		super.applyConfiguration(properties);
+		
+	}
+
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties properties = super.getConfiguration();
+		
+		if (comparator instanceof LinearDominanceComparator) {
+			properties.setString("method", "linear");
+		} else if (comparator instanceof MinMaxDominanceComparator) {
+			properties.setString("method", "min-max");
+		}
+		
+		properties.setDoubleArray("weights", comparator.getWeights());
+		
+		return properties;
+	}
+
+}

--- a/src/org/moeaframework/algorithm/single/VectorAngleDistanceScalingComparator.java
+++ b/src/org/moeaframework/algorithm/single/VectorAngleDistanceScalingComparator.java
@@ -69,6 +69,11 @@ public class VectorAngleDistanceScalingComparator implements AggregateObjectiveC
 		this.weights = weights;
 		this.q = q;
 	}
+	
+	@Override
+	public double[] getWeights() {
+		return weights;
+	}
 
 	@Override
 	public int compare(Solution solution1, Solution solution2) {

--- a/src/org/moeaframework/analysis/sensitivity/ResultFileWriter.java
+++ b/src/org/moeaframework/analysis/sensitivity/ResultFileWriter.java
@@ -297,6 +297,7 @@ public class ResultFileWriter implements OutputWriter {
 		try (StringWriter stringBuffer = new StringWriter()) {
 			properties.store(stringBuffer);
 		
+			// TODO: use CommentedLineReader
 			try (BufferedReader reader = new BufferedReader(new StringReader(stringBuffer.toString()))) {
 				reader.readLine(); //skip first line that contains the timestamp
 				

--- a/src/org/moeaframework/analysis/tools/Solve.java
+++ b/src/org/moeaframework/analysis/tools/Solve.java
@@ -497,10 +497,9 @@ public class Solve extends CommandLineUtility {
 		
 		try {
 			int count = 0;
-			RandomInitialization initialization = new RandomInitialization(
-					problem, trials);
+			RandomInitialization initialization = new RandomInitialization(problem);
 			
-			Solution[] solutions = initialization.initialize();
+			Solution[] solutions = initialization.initialize(trials);
 			
 			for (Solution solution : solutions) {
 				System.out.println("Running test " + (++count) + ":");

--- a/src/org/moeaframework/core/Initialization.java
+++ b/src/org/moeaframework/core/Initialization.java
@@ -28,6 +28,6 @@ public interface Initialization {
 	 * 
 	 * @return an array of solutions to become the initial population
 	 */
-	public Solution[] initialize();
+	public Solution[] initialize(int populationSize);
 
 }

--- a/src/org/moeaframework/core/Variation.java
+++ b/src/org/moeaframework/core/Variation.java
@@ -17,6 +17,8 @@
  */
 package org.moeaframework.core;
 
+import org.moeaframework.core.configuration.Configurable;
+
 /**
  * Interface for variation operators. Variation operators manipulate one or more existing solutions, called
  * <em>parents</em>, to produce one or more new solutions, called <em>children</em> or <em>offspring</em>.
@@ -29,7 +31,7 @@ package org.moeaframework.core;
  * Mixed-type encodings are supported by using type-safe variation operators. Variation operators for each type in the
  * encoding are applied sequentially, each operating on only those variables with the correct type.
  */
-public interface Variation {
+public interface Variation extends Configurable {
 	
 	/**
 	 * Returns the name of this variation operator.  This name should also be used as the prefix for any

--- a/src/org/moeaframework/core/comparator/ChainedComparator.java
+++ b/src/org/moeaframework/core/comparator/ChainedComparator.java
@@ -48,7 +48,7 @@ public class ChainedComparator implements DominanceComparator, Serializable {
 	/**
 	 * The comparators in the order they are to be applied.
 	 */
-	private DominanceComparator[] comparators;
+	protected DominanceComparator[] comparators;
 
 	/**
 	 * Constructs a chained comparator for applying the specified comparators in

--- a/src/org/moeaframework/core/configuration/Configurable.java
+++ b/src/org/moeaframework/core/configuration/Configurable.java
@@ -1,0 +1,60 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.configuration;
+
+import org.moeaframework.util.TypedProperties;
+
+/**
+ * Interface for classes that can be configured either explicitly by overriding the methods defined by this
+ * interface or auto-configurable by using the annotations available in this package.
+ * 
+ * With auto-configuration, in addition to processing annotated setters, it will also check each getter method
+ * and recursively process any that also implement this interface.  However, it will not scan any collection
+ * types, such as {@code Iterable}, {@code Collection}, {@code List}, etc., even if they contain
+ * {@code Configurable} types.
+ */
+public interface Configurable {
+	
+	/**
+	 * Applies the properties to this instance.  It is strongly recommended to apply a configuration immediately
+	 * after creating the instance, as some properties can not be changed after the class is used.  Exceptions
+	 * may be thrown if attempting to set such properties.
+	 * 
+	 * After calling this method, we encourage users to call {@link TypedProperties#warnIfUnaccessedProperties()}
+	 * to verify all properties were processed.  This can identify simple mistakes like typos.
+	 * 
+	 * If overriding this method, properties should only be updated if a new value is provided.
+	 * 
+	 * @param properties the user-defined properties
+	 */
+	default public void applyConfiguration(TypedProperties properties) {
+		ConfigurationUtils.applyConfiguration(properties, this);
+	}
+	
+	/**
+	 * Gets the current configuration of this instance.  In theory, these properties should be able to create a
+	 * duplicate instance.  Note however, they are unlikely to behave identically due to random numbers and other
+	 * transient fields.
+	 * 
+	 * @return the properties defining this instance
+	 */
+	default public TypedProperties getConfiguration() {
+		return ConfigurationUtils.getConfiguration(this);
+	}
+
+}

--- a/src/org/moeaframework/core/configuration/ConfigurationException.java
+++ b/src/org/moeaframework/core/configuration/ConfigurationException.java
@@ -1,0 +1,28 @@
+package org.moeaframework.core.configuration;
+
+import org.moeaframework.core.FrameworkException;
+
+/**
+ * Indicates an error occurred when configuring an object or reading properties.
+ */
+public class ConfigurationException extends FrameworkException {
+
+	private static final long serialVersionUID = -2401741284126446554L;
+
+	public ConfigurationException() {
+		super();
+	}
+
+	public ConfigurationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ConfigurationException(String message) {
+		super(message);
+	}
+
+	public ConfigurationException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/org/moeaframework/core/configuration/ConfigurationUtils.java
+++ b/src/org/moeaframework/core/configuration/ConfigurationUtils.java
@@ -1,0 +1,228 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.configuration;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.commons.text.WordUtils;
+import org.moeaframework.core.Algorithm;
+import org.moeaframework.core.FrameworkException;
+import org.moeaframework.core.Problem;
+import org.moeaframework.core.Variation;
+import org.moeaframework.core.spi.OperatorFactory;
+import org.moeaframework.util.TypedProperties;
+
+public class ConfigurationUtils {
+	
+	private ConfigurationUtils() {
+		super();
+	}
+	
+	public static void applyConfiguration(TypedProperties properties, Configurable object) {
+		Problem problem = null;
+		
+		if (object instanceof Algorithm) {
+			problem = ((Algorithm)object).getProblem();
+		}
+		
+		applyConfiguration(properties, object, problem);
+	}
+	
+	public static void applyConfiguration(TypedProperties properties, Configurable object, Problem problem) {
+		Class<?> type = object.getClass();
+
+		// process properties defined in this class
+		for (Method method : MethodUtils.getMethodsWithAnnotation(type, Property.class, false, false)) {
+			String methodName = method.getName();
+			Property property = method.getAnnotation(Property.class);
+			
+			if (isSetter(method)) {
+				String propertyName = property.value().isEmpty() ?
+						WordUtils.uncapitalize(methodName.substring(3)) :
+						property.value();
+
+				ConfigurationUtils.applyValue(properties, propertyName, property.synonym(), method, object, problem);
+			} else {
+				System.err.println("found @Property annotation on non-setter method " + methodName + " in class " +
+					type.getSimpleName() + ", ignoring");
+			}
+		}
+		
+		// process any configurable objects referenced by this class
+		for (Method method : type.getMethods()) {
+			if (isGetter(method, Configurable.class)) {
+				Configurable nestedObject = safeInvokeGetter(method, object, Configurable.class);
+					
+				if (nestedObject != null) {
+					nestedObject.applyConfiguration(properties);
+				}
+			}
+		}
+	}
+	
+	public static TypedProperties getConfiguration(Configurable object) {
+		TypedProperties properties = new TypedProperties();
+		Class<?> type = object.getClass();
+		Prefix prefix = type.getAnnotation(Prefix.class);
+
+		// process properties defined in this class
+		for (Method method : MethodUtils.getMethodsWithAnnotation(type, Property.class, false, false)) {
+			String methodName = method.getName();
+			Property property = method.getAnnotation(Property.class);
+			
+			if (methodName.startsWith("set") && method.getParameterCount() == 1) {
+				String propertyName = property.value().isEmpty() ?
+						WordUtils.uncapitalize(methodName.substring(3)) :
+						property.value();
+				
+				if (prefix != null && !prefix.value().isEmpty()) {
+					propertyName = prefix.value() + "." + propertyName;
+				}
+				
+				Method getter = MethodUtils.getAccessibleMethod(type, "get" + methodName.substring(3));
+				
+				if (getter == null && boolean.class.isAssignableFrom(method.getParameterTypes()[0])) {
+					getter = MethodUtils.getAccessibleMethod(type, "is" + methodName.substring(3));
+				}
+				
+				if (getter != null) {
+					ConfigurationUtils.extractValue(properties, propertyName, getter, object);
+				} else {
+					System.err.println("no getter method found for property " + propertyName);
+				}
+			} else {
+				System.err.println("found @Property annotation on non-setter method " + methodName + " in class " +
+					type.getSimpleName() + ", ignoring");
+			}
+		}
+		
+		// process any configurable objects referenced by this class
+		for (Method method : type.getMethods()) {
+			if (isGetter(method, Configurable.class)) {
+				Configurable nestedObject = safeInvokeGetter(method, object, Configurable.class);
+					
+				if (nestedObject != null) {
+					properties.addAll(nestedObject.getConfiguration());
+				}
+			}
+		}
+		
+		return properties;
+	}
+	
+	private static void applyValue(TypedProperties properties, String propertyName, String[] synonyms,
+			Method method, Configurable object, Problem problem) {
+		propertyName = findPropertyName(properties, propertyName, synonyms);
+		
+		if (propertyName == null) {
+			return;
+		}
+		
+		Class<?> parameterType = method.getParameterTypes()[0];
+		Object value = null;
+
+		if (double.class.isAssignableFrom(parameterType)) {
+			value = properties.getDouble(propertyName, 0.0);
+		} else if (int.class.isAssignableFrom(parameterType)) {
+			value = properties.getInt(propertyName, 0);
+		} else if (boolean.class.isAssignableFrom(parameterType)) {
+			value = properties.getBoolean(propertyName, false);
+		} else if (String.class.isAssignableFrom(parameterType)) {
+			value = properties.getString(propertyName, null);
+		} else if (Variation.class.isAssignableFrom(parameterType)) {
+			if (problem == null) {
+				throw new ConfigurationException("must provide problem if setting variation operator");
+			}
+			
+			String operator = properties.getString(propertyName, null);
+			value = OperatorFactory.getInstance().getVariation(operator, properties, problem);
+		} else {
+			throw new ConfigurationException("unsupported type " + parameterType + " for property " + propertyName);
+		}
+		
+		try {
+			method.invoke(object, value);
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new FrameworkException("failed to apply property " + propertyName, e);
+		}
+	}
+	
+	private static void extractValue(TypedProperties properties, String propertyName, Method method,
+			Configurable object) {
+		Class<?> parameterType = method.getReturnType();
+
+		try {
+			Object value = method.invoke(object);
+			
+			if (double.class.isAssignableFrom(parameterType)) {
+				properties.setDouble(propertyName, (double)value);
+			} else if (int.class.isAssignableFrom(parameterType)) {
+				properties.setInt(propertyName, (int)value);
+			} else if (boolean.class.isAssignableFrom(parameterType)) {
+				properties.setBoolean(propertyName, (boolean)value);
+			} else if (String.class.isAssignableFrom(parameterType)) {
+				properties.setString(propertyName, (String)value);
+			} else if (Variation.class.isAssignableFrom(parameterType)) {
+				properties.setString(propertyName, ((Variation)value).getName());
+			} else {
+				throw new ConfigurationException("unsupported type " + parameterType + " for property " + propertyName);
+			}
+			
+			if (value instanceof Configurable) {
+				TypedProperties valueProperties = ((Configurable)value).getConfiguration();
+				properties.addAll(valueProperties);
+			}
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new ConfigurationException("failed to read property " + propertyName, e);
+		}
+	}
+	
+	private static String findPropertyName(TypedProperties properties, String propertyName, String[] synonyms) {
+		if (properties.contains(propertyName)) {
+			return propertyName;
+		}
+		
+		for (String synonym : synonyms) {
+			if (properties.contains(synonym)) {
+				return synonym;
+			}
+		}
+				
+		return null;
+	}
+	
+	private static boolean isGetter(Method method, Class<?> returnType) {
+		return method.getName().startsWith("get") && method.getParameterCount() == 0 &&
+				returnType.isAssignableFrom(method.getReturnType());
+	}
+	
+	private static boolean isSetter(Method method) {
+		return method.getName().startsWith("set") && method.getParameterCount() == 1;
+	}
+	
+	private static <T> T safeInvokeGetter(Method method, Configurable object, Class<T> returnType) {
+		try {
+			return returnType.cast(method.invoke(object));
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new ConfigurationException("failed to call " + method.getName(), e);
+		}
+	}
+
+}

--- a/src/org/moeaframework/core/configuration/Prefix.java
+++ b/src/org/moeaframework/core/configuration/Prefix.java
@@ -1,0 +1,39 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation identifying the prefix used on all properties contained within the annotated class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Prefix {
+	
+	/**
+	 * The prefix value used on all properties.
+	 * 
+	 * @return the prefix value
+	 */
+	String value();
+
+}

--- a/src/org/moeaframework/core/configuration/Property.java
+++ b/src/org/moeaframework/core/configuration/Property.java
@@ -1,0 +1,54 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation added to setter methods that identify auto-configurable properties.  The methods must follow
+ * JavaBean naming conventions.  For a property named {@code foo}, then we expected to see the methods:
+ * <pre>
+ *    public void setFoo(T value) { ... }
+ *    public T getFoo() { ... }
+ * </pre>
+ * for one of the supported types {@code T}.  If the type is {@code boolean}, then the getter can alternatively
+ * be named {@code isFoo}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Property {
+	
+	/**
+	 * The name of this property.  If unset, the name is derived from the method name.  To help disambiguate
+	 * property names, especially for variation operators, consider adding the {@link Prefix} annotation.
+	 * 
+	 * @return the name of this property
+	 */
+	String value() default "";
+	
+	/**
+	 * One or more alternate names used by this property.
+	 * 
+	 * @return the synonyms for this property
+	 */
+	String[] synonym() default {};
+
+}

--- a/src/org/moeaframework/core/configuration/package-info.java
+++ b/src/org/moeaframework/core/configuration/package-info.java
@@ -1,0 +1,22 @@
+/* Copyright 2009-2022 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Support for configuring algorithms.
+ */
+package org.moeaframework.core.configuration;

--- a/src/org/moeaframework/core/operator/AbstractCompoundVariation.java
+++ b/src/org/moeaframework/core/operator/AbstractCompoundVariation.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.util.TypedProperties;
 
 /**
  * Construct a variation operator applying one or more variations sequentially.
@@ -156,6 +157,24 @@ public class AbstractCompoundVariation<T extends Variation> implements Variation
 	 */
 	public List<T> getOperators() {
 		return Collections.unmodifiableList(operators);
+	}
+	
+	@Override
+	public void applyConfiguration(TypedProperties properties) {
+		for (T operator : operators) {
+			operator.applyConfiguration(properties);
+		}
+	}
+	
+	@Override
+	public TypedProperties getConfiguration() {
+		TypedProperties result = new TypedProperties();
+		
+		for (T operator : operators) {
+			result.addAll(operator.getConfiguration());
+		}
+		
+		return result;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/InjectedInitialization.java
+++ b/src/org/moeaframework/core/operator/InjectedInitialization.java
@@ -37,47 +37,43 @@ public class InjectedInitialization extends RandomInitialization {
 	private List<Solution> injectedSolutions;
 
 	/**
-	 * Constructs a random initialization operator that includes one or more
-	 * pre-defined solutions.
+	 * Constructs a random initialization operator that includes one or more pre-defined solutions.
 	 * 
 	 * @param problem the problem
-	 * @param populationSize the initial population size
-	 * @param injectedSolutions the pre-defined solutions injected into the
-	 *        initial population
+	 * @param injectedSolutions the pre-defined solutions injected into the initial population
 	 */
-	public InjectedInitialization(Problem problem, int populationSize,
-			Solution... injectedSolutions) {
-		this(problem, populationSize, Arrays.asList(injectedSolutions));
+	public InjectedInitialization(Problem problem, Solution... injectedSolutions) {
+		this(problem, Arrays.asList(injectedSolutions));
 	}
 	
 	/**
-	 * Constructs a random initialization operator that includes one or more
-	 * pre-defined solutions.
+	 * Constructs a random initialization operator that includes one or more pre-defined solutions.
 	 * 
 	 * @param problem the problem
-	 * @param populationSize the initial population size
-	 * @param injectedSolutions the pre-defined solutions injected into the
-	 *        initial population
+	 * @param injectedSolutions the pre-defined solutions injected into the initial population
 	 */
-	public InjectedInitialization(Problem problem, int populationSize,
-			List<Solution> injectedSolutions) {
-		super(problem, populationSize);
+	public InjectedInitialization(Problem problem, List<Solution> injectedSolutions) {
+		super(problem);
 		this.injectedSolutions = new ArrayList<Solution>(injectedSolutions);
 	}
 
 	@Override
-	public Solution[] initialize() {
-		if (populationSize <= injectedSolutions.size()) {
-			return injectedSolutions.toArray(new Solution[0]);
-		} else {
-			Solution[] initialPopulation = super.initialize();
-			
-			for (int i = 0; i < injectedSolutions.size(); i++) {
-				initialPopulation[i] = injectedSolutions.get(i);
-			}
-			
-			return initialPopulation;
+	public Solution[] initialize(int populationSize) {
+		Solution[] initialPopulation = new Solution[populationSize];
+		
+		for (int i = 0; i < Math.min(injectedSolutions.size(), populationSize); i++) {
+			initialPopulation[i] = injectedSolutions.get(i);
 		}
+		
+		if (injectedSolutions.size() < populationSize) {
+			Solution[] randomSolutions = super.initialize(populationSize - injectedSolutions.size());
+			
+			for (int i = injectedSolutions.size(); i < populationSize; i++) {
+				initialPopulation[i] = randomSolutions[i - injectedSolutions.size()];
+			}
+		}
+
+		return initialPopulation;
 	}
 
 }

--- a/src/org/moeaframework/core/operator/OnePointCrossover.java
+++ b/src/org/moeaframework/core/operator/OnePointCrossover.java
@@ -21,12 +21,15 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 
 /**
  * One-point or single-point crossover. A crossover point is selected and all
  * decision variables to the left/right are swapped between the two parents. The
  * two children resulting from this swapping are returned.
  */
+@Prefix("1x")
 public class OnePointCrossover implements Variation {
 
 	/**
@@ -70,6 +73,7 @@ public class OnePointCrossover implements Variation {
 	 * 
 	 * @param probability the probability between 0.0 and 1.0, inclusive
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}

--- a/src/org/moeaframework/core/operator/RandomInitialization.java
+++ b/src/org/moeaframework/core/operator/RandomInitialization.java
@@ -34,24 +34,17 @@ public class RandomInitialization implements Initialization {
 	protected final Problem problem;
 
 	/**
-	 * The initial population size.
-	 */
-	protected final int populationSize;
-
-	/**
 	 * Constructs a random initialization operator.
 	 * 
 	 * @param problem the problem
-	 * @param populationSize the initial population size
 	 */
-	public RandomInitialization(Problem problem, int populationSize) {
+	public RandomInitialization(Problem problem) {
 		super();
 		this.problem = problem;
-		this.populationSize = populationSize;
 	}
 
 	@Override
-	public Solution[] initialize() {
+	public Solution[] initialize(int populationSize) {
 		Solution[] initialPopulation = new Solution[populationSize];
 
 		for (int i = 0; i < populationSize; i++) {

--- a/src/org/moeaframework/core/operator/TwoPointCrossover.java
+++ b/src/org/moeaframework/core/operator/TwoPointCrossover.java
@@ -21,12 +21,15 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 
 /**
  * Two-point crossover. Two crossover points are selected and all decision
  * variables between the two points are swapped between the two parents. The two
  * children resulting from this swapping are returned.
  */
+@Prefix("2x")
 public class TwoPointCrossover implements Variation {
 
 	/**
@@ -70,6 +73,7 @@ public class TwoPointCrossover implements Variation {
 	 * 
 	 * @param probability the probability between 0.0 and 1.0, inclusive
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}

--- a/src/org/moeaframework/core/operator/TypeSafeCrossover.java
+++ b/src/org/moeaframework/core/operator/TypeSafeCrossover.java
@@ -4,6 +4,7 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Property;
 
 /**
  * An abstract variation class that validates the types of each variable before
@@ -49,6 +50,7 @@ public abstract class TypeSafeCrossover<T extends Variable> implements Variation
 	 * 
 	 * @param probability the probability between 0.0 and 1.0, inclusive
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}

--- a/src/org/moeaframework/core/operator/TypeSafeMutation.java
+++ b/src/org/moeaframework/core/operator/TypeSafeMutation.java
@@ -3,6 +3,7 @@ package org.moeaframework.core.operator;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
+import org.moeaframework.core.configuration.Property;
 
 /**
  * An abstract mutation class that validates the types of each variable before
@@ -48,6 +49,7 @@ public abstract class TypeSafeMutation<T extends Variable> implements Mutation {
 	 * 
 	 * @param probability the probability between 0.0 and 1.0, inclusive
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}

--- a/src/org/moeaframework/core/operator/UniformCrossover.java
+++ b/src/org/moeaframework/core/operator/UniformCrossover.java
@@ -21,11 +21,14 @@ import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 
 /**
  * Crossover operator where each index is randomly swapped between the
  * parents with a 50% chance.
  */
+@Prefix("ux")
 public class UniformCrossover implements Variation {
 
 	/**
@@ -70,6 +73,7 @@ public class UniformCrossover implements Variation {
 	 * 
 	 * @param probability the probability between 0.0 and 1.0, inclusive
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}

--- a/src/org/moeaframework/core/operator/binary/BitFlip.java
+++ b/src/org/moeaframework/core/operator/binary/BitFlip.java
@@ -20,6 +20,8 @@ package org.moeaframework.core.operator.binary;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.BinaryVariable;
 
@@ -29,6 +31,7 @@ import org.moeaframework.core.variable.BinaryVariable;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("bf")
 public class BitFlip implements Mutation {
 
 	/**
@@ -72,6 +75,7 @@ public class BitFlip implements Mutation {
 	 * 
 	 * @param probability the probability of flipping a bit
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}

--- a/src/org/moeaframework/core/operator/binary/HUX.java
+++ b/src/org/moeaframework/core/operator/binary/HUX.java
@@ -19,6 +19,7 @@ package org.moeaframework.core.operator.binary;
 
 import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeCrossover;
 import org.moeaframework.core.variable.BinaryVariable;
 
@@ -28,6 +29,7 @@ import org.moeaframework.core.variable.BinaryVariable;
  * <p>
  * This variation operator is type-safe.
  */
+@Prefix("hux")
 public class HUX extends TypeSafeCrossover<BinaryVariable> {
 
 	/**

--- a/src/org/moeaframework/core/operator/grammar/GrammarCrossover.java
+++ b/src/org/moeaframework/core/operator/grammar/GrammarCrossover.java
@@ -18,6 +18,7 @@
 package org.moeaframework.core.operator.grammar;
 
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeCrossover;
 import org.moeaframework.core.variable.Grammar;
 
@@ -27,6 +28,7 @@ import org.moeaframework.core.variable.Grammar;
  * <p>
  * This variation operator is type-safe.
  */
+@Prefix("gx")
 public class GrammarCrossover extends TypeSafeCrossover<Grammar> {
 	
 	/**

--- a/src/org/moeaframework/core/operator/grammar/GrammarMutation.java
+++ b/src/org/moeaframework/core/operator/grammar/GrammarMutation.java
@@ -20,6 +20,7 @@ package org.moeaframework.core.operator.grammar;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.Grammar;
 
@@ -29,6 +30,7 @@ import org.moeaframework.core.variable.Grammar;
  * <p>
  * This variation operator is type-safe.
  */
+@Prefix("gm")
 public class GrammarMutation implements Mutation {
 
 	/**

--- a/src/org/moeaframework/core/operator/permutation/Insertion.java
+++ b/src/org/moeaframework/core/operator/permutation/Insertion.java
@@ -18,6 +18,7 @@
 package org.moeaframework.core.operator.permutation;
 
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeMutation;
 import org.moeaframework.core.variable.Permutation;
 
@@ -27,6 +28,7 @@ import org.moeaframework.core.variable.Permutation;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("insertion")
 public class Insertion extends TypeSafeMutation<Permutation> {
 
 	/**

--- a/src/org/moeaframework/core/operator/permutation/PMX.java
+++ b/src/org/moeaframework/core/operator/permutation/PMX.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeCrossover;
 import org.moeaframework.core.variable.Permutation;
 
@@ -38,6 +39,7 @@ import org.moeaframework.core.variable.Permutation;
  * International Conference on Genetic Algorithms and Their Applications. 1985.
  * </ol>
  */
+@Prefix("pmx")
 public class PMX extends TypeSafeCrossover<Permutation> {
 
 	/**

--- a/src/org/moeaframework/core/operator/permutation/Swap.java
+++ b/src/org/moeaframework/core/operator/permutation/Swap.java
@@ -18,6 +18,7 @@
 package org.moeaframework.core.operator.permutation;
 
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeMutation;
 import org.moeaframework.core.variable.Permutation;
 
@@ -27,6 +28,7 @@ import org.moeaframework.core.variable.Permutation;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("swap")
 public class Swap extends TypeSafeMutation<Permutation> {
 
 	/**

--- a/src/org/moeaframework/core/operator/program/PointMutation.java
+++ b/src/org/moeaframework/core/operator/program/PointMutation.java
@@ -22,6 +22,8 @@ import java.util.List;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.Mutation;
 import org.moeaframework.core.variable.Program;
 import org.moeaframework.util.tree.Node;
@@ -33,6 +35,7 @@ import org.moeaframework.util.tree.Rules;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("ptm")
 public class PointMutation implements Mutation {
 	
 	/**
@@ -76,6 +79,7 @@ public class PointMutation implements Mutation {
 	 * 
 	 * @param probability the probability (0.0 - 1.0)
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}

--- a/src/org/moeaframework/core/operator/program/SubtreeCrossover.java
+++ b/src/org/moeaframework/core/operator/program/SubtreeCrossover.java
@@ -19,6 +19,7 @@ package org.moeaframework.core.operator.program;
 
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeCrossover;
 import org.moeaframework.core.variable.Program;
 import org.moeaframework.util.tree.Node;
@@ -30,6 +31,7 @@ import org.moeaframework.util.tree.Rules;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("stx")
 public class SubtreeCrossover extends TypeSafeCrossover<Program> {
 	
 	/**

--- a/src/org/moeaframework/core/operator/real/AdaptiveMetropolis.java
+++ b/src/org/moeaframework/core/operator/real/AdaptiveMetropolis.java
@@ -25,6 +25,8 @@ import org.apache.commons.math3.linear.RealVector;
 import org.apache.commons.math3.stat.correlation.Covariance;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
 
@@ -54,6 +56,7 @@ import org.moeaframework.core.variable.RealVariable;
  *       Jumping Rules."  Bayesian Statistics, vol. 5, pp. 599-607, 1996.
  * </ol>
  */
+@Prefix("am")
 public class AdaptiveMetropolis extends MultiParentVariation {
 	
 	/**
@@ -108,6 +111,7 @@ public class AdaptiveMetropolis extends MultiParentVariation {
 	 * 
 	 * @param jumpRateCoefficient the jump rate coefficient value
 	 */
+	@Property("coefficient")
 	public void setJumpRateCoefficient(double jumpRateCoefficient) {
 		this.jumpRateCoefficient = jumpRateCoefficient;
 	}

--- a/src/org/moeaframework/core/operator/real/DifferentialEvolutionVariation.java
+++ b/src/org/moeaframework/core/operator/real/DifferentialEvolutionVariation.java
@@ -20,6 +20,8 @@ package org.moeaframework.core.operator.real;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.variable.RealVariable;
 
 /**
@@ -45,6 +47,7 @@ import org.moeaframework.core.variable.RealVariable;
  * Optimization, 11:341-359, 1997.
  * </ol>
  */
+@Prefix("de")
 public class DifferentialEvolutionVariation implements Variation {
 
 	/**
@@ -97,6 +100,7 @@ public class DifferentialEvolutionVariation implements Variation {
 	 * 
 	 * @param CR the crossover rate
 	 */
+	@Property
 	public void setCrossoverRate(double CR) {
 		this.CR = CR;
 	}
@@ -116,6 +120,7 @@ public class DifferentialEvolutionVariation implements Variation {
 	 * 
 	 * @param F the scaling factor
 	 */
+	@Property("stepSize")
 	public void setScalingFactor(double F) {
 		this.F = F;
 	}

--- a/src/org/moeaframework/core/operator/real/MultiParentVariation.java
+++ b/src/org/moeaframework/core/operator/real/MultiParentVariation.java
@@ -1,6 +1,7 @@
 package org.moeaframework.core.operator.real;
 
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Property;
 
 /**
  * Abstract class for operators that can take a variable number of parents
@@ -45,6 +46,7 @@ public abstract class MultiParentVariation implements Variation {
 	 * 
 	 * @param numberOfParents the number of parents required by this operator
 	 */
+	@Property("parents")
 	public void setNumberOfParents(int numberOfParents) {
 		this.numberOfParents = numberOfParents;
 	}
@@ -63,6 +65,7 @@ public abstract class MultiParentVariation implements Variation {
 	 * 
 	 * @param numberOfOffspring the number of offspring produced by this operator
 	 */
+	@Property("offspring")
 	public void setNumberOfOffspring(int numberOfOffspring) {
 		this.numberOfOffspring = numberOfOffspring;
 	}

--- a/src/org/moeaframework/core/operator/real/PCX.java
+++ b/src/org/moeaframework/core/operator/real/PCX.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.util.Vector;
 
@@ -39,6 +41,7 @@ import org.moeaframework.util.Vector;
  *       Computation, 10(4):371-395, 2002.
  * </ol>
  */
+@Prefix("pcx")
 public class PCX extends MultiParentVariation {
 	
 	/**
@@ -118,6 +121,7 @@ public class PCX extends MultiParentVariation {
 	 * 
 	 * @param eta the standard deviation value
 	 */
+	@Property
 	public void setEta(double eta) {
 		this.eta = eta;
 	}
@@ -139,6 +143,7 @@ public class PCX extends MultiParentVariation {
 	 * 
 	 * @param zeta the standard deviation value
 	 */
+	@Property
 	public void setZeta(double zeta) {
 		this.zeta = zeta;
 	}

--- a/src/org/moeaframework/core/operator/real/PM.java
+++ b/src/org/moeaframework/core/operator/real/PM.java
@@ -18,6 +18,8 @@
 package org.moeaframework.core.operator.real;
 
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.operator.TypeSafeMutation;
 import org.moeaframework.core.variable.RealVariable;
 
@@ -43,6 +45,7 @@ import org.moeaframework.core.variable.RealVariable;
  *       26(4):30-45, 1996.
  * </ol>
  */
+@Prefix("pm")
 public class PM extends TypeSafeMutation<RealVariable> {
 
 	/**
@@ -88,6 +91,7 @@ public class PM extends TypeSafeMutation<RealVariable> {
 	 * 
 	 * @param distributionIndex the distribution index controlling the shape of the polynomial mutation
 	 */
+	@Property
 	public void setDistributionIndex(double distributionIndex) {
 		this.distributionIndex = distributionIndex;
 	}

--- a/src/org/moeaframework/core/operator/real/SBX.java
+++ b/src/org/moeaframework/core/operator/real/SBX.java
@@ -22,6 +22,8 @@ import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.Variable;
 import org.moeaframework.core.Variation;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.variable.RealVariable;
 
 /**
@@ -45,6 +47,7 @@ import org.moeaframework.core.variable.RealVariable;
  *       Technical Report No. IITK/ME/SMD-94027, 1994.
  * </ol>
  */
+@Prefix("sbx")
 public class SBX implements Variation {
 
 	/**
@@ -98,8 +101,7 @@ public class SBX implements Variation {
 	 * @param swap if {@code true}, randomly swap the variables between the two parents
 	 * @param symmetric if {@code true}, symmetric distrubutions are used
 	 */
-	public SBX(double probability, double distributionIndex, boolean swap,
-			boolean symmetric) {
+	public SBX(double probability, double distributionIndex, boolean swap, boolean symmetric) {
 		super();
 		this.probability = probability;
 		this.distributionIndex = distributionIndex;
@@ -126,6 +128,7 @@ public class SBX implements Variation {
 	 * 
 	 * @param probability the probability (0.0 - 1.0)
 	 */
+	@Property("rate")
 	public void setProbability(double probability) {
 		this.probability = probability;
 	}
@@ -144,6 +147,7 @@ public class SBX implements Variation {
 	 * 
 	 * @param distributionIndex the distribution index
 	 */
+	@Property("distributionIndex")
 	public void setDistributionIndex(double distributionIndex) {
 		this.distributionIndex = distributionIndex;
 	}
@@ -164,6 +168,7 @@ public class SBX implements Variation {
 	 * 
 	 * @param swap {@code true} if this SBX operator swaps variables between the two parents
 	 */
+	@Property
 	public void setSwap(boolean swap) {
 		this.swap = swap;
 	}
@@ -185,6 +190,7 @@ public class SBX implements Variation {
 	 * @param symmetric {@code true} if the offspring are distributed symmetrically; or
 	 *         {@code false} if asymmetric distributions are used
 	 */
+	@Property
 	public void setSymmetric(boolean symmetric) {
 		this.symmetric = symmetric;
 	}
@@ -204,8 +210,7 @@ public class SBX implements Variation {
 				Variable variable1 = result1.getVariable(i);
 				Variable variable2 = result2.getVariable(i);
 
-				if (PRNG.nextBoolean() && (variable1 instanceof RealVariable)
-						&& (variable2 instanceof RealVariable)) {
+				if (PRNG.nextBoolean() && (variable1 instanceof RealVariable) && (variable2 instanceof RealVariable)) {
 					if (symmetric) {
 						evolve_symmetric((RealVariable)variable1,
 								(RealVariable)variable2, distributionIndex,

--- a/src/org/moeaframework/core/operator/real/SPX.java
+++ b/src/org/moeaframework/core/operator/real/SPX.java
@@ -19,6 +19,8 @@ package org.moeaframework.core.operator.real;
 
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.variable.RealVariable;
 
 /**
@@ -42,6 +44,7 @@ import org.moeaframework.core.variable.RealVariable;
  * Solving from Nature PPSN VI, pp. 365-374, 2000.
  * </ol>
  */
+@Prefix("spx")
 public class SPX extends MultiParentVariation {
 
 	/**
@@ -177,6 +180,7 @@ public class SPX extends MultiParentVariation {
 	 * 
 	 * @param epsilon the expansion rate
 	 */
+	@Property
 	public void setEpsilon(double epsilon) {
 		this.epsilon = epsilon;
 	}

--- a/src/org/moeaframework/core/operator/real/UM.java
+++ b/src/org/moeaframework/core/operator/real/UM.java
@@ -18,6 +18,7 @@
 package org.moeaframework.core.operator.real;
 
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeMutation;
 import org.moeaframework.core.variable.RealVariable;
 
@@ -34,6 +35,7 @@ import org.moeaframework.core.variable.RealVariable;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("um")
 public class UM extends TypeSafeMutation<RealVariable> {
 	
 	/**

--- a/src/org/moeaframework/core/operator/real/UNDX.java
+++ b/src/org/moeaframework/core/operator/real/UNDX.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.configuration.Prefix;
+import org.moeaframework.core.configuration.Property;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.util.Vector;
 
@@ -45,6 +47,7 @@ import org.moeaframework.util.Vector;
  * Computation, vol. 10, no. 4, pp. 371-395, 2002.
  * </ol>
  */
+@Prefix("undx")
 public class UNDX extends MultiParentVariation {
 
 	/**
@@ -126,6 +129,7 @@ public class UNDX extends MultiParentVariation {
 	 * 
 	 * @param zeta the standard deviation value
 	 */
+	@Property
 	public void setZeta(double zeta) {
 		this.zeta = zeta;
 	}
@@ -150,6 +154,7 @@ public class UNDX extends MultiParentVariation {
 	 * 
 	 * @param eta the standard deviation value
 	 */
+	@Property
 	public void setEta(double eta) {
 		this.eta = eta;
 	}

--- a/src/org/moeaframework/core/operator/subset/Add.java
+++ b/src/org/moeaframework/core/operator/subset/Add.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.core.operator.subset;
 
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeMutation;
 import org.moeaframework.core.variable.Subset;
 
@@ -25,6 +26,7 @@ import org.moeaframework.core.variable.Subset;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("add")
 public class Add extends TypeSafeMutation<Subset> {
 
 	/**

--- a/src/org/moeaframework/core/operator/subset/Remove.java
+++ b/src/org/moeaframework/core/operator/subset/Remove.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.core.operator.subset;
 
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeMutation;
 import org.moeaframework.core.variable.Subset;
 
@@ -25,6 +26,7 @@ import org.moeaframework.core.variable.Subset;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("remove")
 public class Remove extends TypeSafeMutation<Subset> {
 	
 	/**

--- a/src/org/moeaframework/core/operator/subset/Replace.java
+++ b/src/org/moeaframework/core/operator/subset/Replace.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.core.operator.subset;
 
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeMutation;
 import org.moeaframework.core.variable.Subset;
 
@@ -25,6 +26,7 @@ import org.moeaframework.core.variable.Subset;
  * <p>
  * This operator is type-safe.
  */
+@Prefix("replace")
 public class Replace extends TypeSafeMutation<Subset> {
 	
 	/**

--- a/src/org/moeaframework/core/operator/subset/SSX.java
+++ b/src/org/moeaframework/core/operator/subset/SSX.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.moeaframework.core.PRNG;
+import org.moeaframework.core.configuration.Prefix;
 import org.moeaframework.core.operator.TypeSafeCrossover;
 import org.moeaframework.core.variable.Subset;
 
@@ -30,6 +31,7 @@ import org.moeaframework.core.variable.Subset;
  * <p>
  * This variation operator is type-safe.
  */
+@Prefix("ssx")
 public class SSX extends TypeSafeCrossover<Subset> {
 
 	/**

--- a/src/org/moeaframework/util/TypedProperties.java
+++ b/src/org/moeaframework/util/TypedProperties.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.moeaframework.core.configuration.ConfigurationException;
 
 /**
  * Stores a collection of key-value pairs similar to {@link Properties} but has support for
@@ -353,7 +354,8 @@ public class TypedProperties {
 				}
 			}
 
-			throw new IllegalArgumentException("enum " + enumType.getSimpleName() + " has no constant of value " + value);
+			throw new IllegalArgumentException("enum " + enumType.getSimpleName() +
+					" has no constant of value " + value);
 		}
 	}
 	
@@ -895,8 +897,18 @@ public class TypedProperties {
 		Set<String> orphanedProperties = getUnaccessedProperties();
 		
 		if (!orphanedProperties.isEmpty()) {
-			System.err.println("properties not accessed: " +
-					String.join(", ", orphanedProperties));
+			System.err.println("properties not accessed: " + String.join(", ", orphanedProperties));
+		}
+	}
+	
+	/**
+	 * Throws a {@link ConfigurationException} if any properties were not accessed.
+	 */
+	public void throwIfUnaccessedProperties() {
+		Set<String> orphanedProperties = getUnaccessedProperties();
+		
+		if (!orphanedProperties.isEmpty()) {
+			throw new ConfigurationException("properties not accessed: " + String.join(", ", orphanedProperties));
 		}
 	}
 

--- a/src/org/moeaframework/util/weights/NormalBoundaryDivisions.java
+++ b/src/org/moeaframework/util/weights/NormalBoundaryDivisions.java
@@ -87,18 +87,47 @@ public class NormalBoundaryDivisions {
 		return innerDivisions > 0;
 	}
 	
+	public TypedProperties toProperties() {
+		TypedProperties properties = new TypedProperties();
+		
+		if (isTwoLayer()) {
+			properties.setInt("divisionsInner", innerDivisions);
+			properties.setInt("divisionsOuter", outerDivisions);
+		} else {
+			properties.setInt("divisions", outerDivisions);
+		}
+		
+		return properties;
+	}
+	
 	/**
 	 * Reads the divisions properties, if set, or provides default values for the problem.
 	 * 
 	 * @param properties the properties
 	 * @param problem the problem
-	 * @return the reference point divisions
+	 * @return the divisions
 	 */
 	public static NormalBoundaryDivisions fromProperties(TypedProperties properties, Problem problem) {
+		NormalBoundaryDivisions divisions = tryFromProperties(properties);
+		
+		if (divisions != null) {
+			return divisions;
+		}
+		
+		return forProblem(problem);
+	}
+	
+	/**
+	 * Reads the division properties, if set.  Otherwise, returns {@code null}.
+	 * 
+	 * @param properties the properties
+	 * @return the divisions or {@code null}
+	 */
+	public static NormalBoundaryDivisions tryFromProperties(TypedProperties properties) {
 		if (properties.contains("divisionsOuter") && properties.contains("divisionsInner")) {
 			return new NormalBoundaryDivisions(
-					(int)properties.getDouble("divisionsOuter", 4),
-					(int)properties.getDouble("divisionsInner", 0));
+					properties.getInt("divisionsOuter", 4),
+					properties.getInt("divisionsInner", 0));
 		} 
 		
 		if (properties.contains("divisionsOuter") || properties.contains("divisionsInner")) {
@@ -106,10 +135,10 @@ public class NormalBoundaryDivisions {
 		}
 		
 		if (properties.contains("divisions")) {
-			return new NormalBoundaryDivisions((int)properties.getDouble("divisions", 4));
+			return new NormalBoundaryDivisions(properties.getInt("divisions", 4));
 		}
 		
-		return forProblem(problem);
+		return null;
 	}
 	
 	/**

--- a/test/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithmTest.java
+++ b/test/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithmTest.java
@@ -48,16 +48,16 @@ public class AbstractEvolutionaryAlgorithmTest {
 		Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");
 		Population population = new Population();
 		NondominatedPopulation archive = new NondominatedPopulation();
-		Initialization initialization = new RandomInitialization(problem, 50);
+		Initialization initialization = new RandomInitialization(problem);
 		Variation variation = OperatorFactory.getInstance().getVariation(problem);
 
-		return new AbstractEvolutionaryAlgorithm(problem, population, archive,
+		return new AbstractEvolutionaryAlgorithm(problem, 50, population, archive,
 				initialization, variation) {
 
 			@Override
 			protected void iterate() {
 				population.clear();
-				population.addAll(initialization.initialize());
+				population.addAll(initialization.initialize(50));
 				evaluateAll(population);
 				archive.addAll(population);
 			}

--- a/test/org/moeaframework/algorithm/AdaptiveTimeContinuationTest.java
+++ b/test/org/moeaframework/algorithm/AdaptiveTimeContinuationTest.java
@@ -123,7 +123,7 @@ public class AdaptiveTimeContinuationTest {
 				algorithm,
 				10,
 				100,
-				4.0,
+				0.25,
 				4,
 				20,
 				new UniformSelection(),

--- a/test/org/moeaframework/algorithm/DBEATest.java
+++ b/test/org/moeaframework/algorithm/DBEATest.java
@@ -48,7 +48,7 @@ public class DBEATest {
 		Problem problem = new DTLZ2(15);
 		
 		DBEA.TESTING_MODE = true;
-		DBEA dbea = new DBEA(problem, null, null, new NormalBoundaryDivisions(3, 0));
+		DBEA dbea = new DBEA(problem, new NormalBoundaryDivisions(3, 0));
 		dbea.generateWeights();
 		
 		String line = null;

--- a/test/org/moeaframework/algorithm/DefaultAlgorithmsResumeTest.java
+++ b/test/org/moeaframework/algorithm/DefaultAlgorithmsResumeTest.java
@@ -315,8 +315,7 @@ public class DefaultAlgorithmsResumeTest {
 		public synchronized Algorithm getAlgorithm(String name, TypedProperties properties,
 				Problem problem) {
 			if (name.equalsIgnoreCase("EpsilonProgressContinuationTest")) {
-				Initialization initialization = new RandomInitialization(
-						problem, 100);
+				Initialization initialization = new RandomInitialization(problem);
 	
 				NondominatedSortingPopulation population = 
 						new NondominatedSortingPopulation(
@@ -335,7 +334,7 @@ public class DefaultAlgorithmsResumeTest {
 						OperatorFactory.getInstance().getVariation(null,
 								new TypedProperties(), problem);
 	
-				NSGAII nsgaii = new NSGAII(problem, population, archive,
+				NSGAII nsgaii = new NSGAII(problem, 100, population, archive,
 						selection, variation, initialization);
 	
 				return new EpsilonProgressContinuation(nsgaii, 100, 100, 4.0,

--- a/test/org/moeaframework/algorithm/EpsilonMOEATest.java
+++ b/test/org/moeaframework/algorithm/EpsilonMOEATest.java
@@ -72,10 +72,10 @@ public class EpsilonMOEATest {
 		
 		population = new TestPopulation();
 		
-		algorithm = new EpsilonMOEA(problem, population, 
+		algorithm = new EpsilonMOEA(problem, 100, population, 
 				new EpsilonBoxDominanceArchive(0.01),
 				new TournamentSelection(2), new CompoundVariation(),
-				new RandomInitialization(problem, 0));
+				new RandomInitialization(problem));
 	}
 	
 	@After

--- a/test/org/moeaframework/algorithm/NSGAIITest.java
+++ b/test/org/moeaframework/algorithm/NSGAIITest.java
@@ -103,8 +103,8 @@ public class NSGAIITest extends AlgorithmTest {
 			
 		};
 
-		NSGAII nsgaii = new NSGAII(problem, new NondominatedSortingPopulation(),
-				null, null, variation, new RandomInitialization(problem, 100));
+		NSGAII nsgaii = new NSGAII(problem, 100, new NondominatedSortingPopulation(),
+				null, null, variation, new RandomInitialization(problem));
 		
 		while (nsgaii.getNumberOfEvaluations() < 100000) {
 			nsgaii.step();

--- a/test/org/moeaframework/algorithm/PESA2Test.java
+++ b/test/org/moeaframework/algorithm/PESA2Test.java
@@ -48,7 +48,7 @@ public class PESA2Test extends AlgorithmTest {
 		Solution solution3 = TestUtils.newSolution(0.001, 0.999);
 		
 		Problem problem = new MockRealProblem(2);
-		PESA2 pesa2 = new PESA2(problem, null, null, 8, 100);
+		PESA2 pesa2 = new PESA2(problem, 0, null, null, 8, 100);
 		pesa2.getArchive().add(solution1);
 		pesa2.getArchive().add(solution2);
 		pesa2.getArchive().add(solution3);
@@ -72,7 +72,7 @@ public class PESA2Test extends AlgorithmTest {
 		Solution solution3 = TestUtils.newSolution(0.001, 0.999);
 		
 		Problem problem = new MockRealProblem(2);
-		PESA2 pesa2 = new PESA2(problem, null, null, 8, 100);
+		PESA2 pesa2 = new PESA2(problem, 0, null, null, 8, 100);
 		pesa2.getArchive().add(solution1);
 		pesa2.getArchive().add(solution2);
 		pesa2.getArchive().add(solution3);

--- a/test/org/moeaframework/algorithm/SPEA2Test.java
+++ b/test/org/moeaframework/algorithm/SPEA2Test.java
@@ -68,7 +68,7 @@ public class SPEA2Test extends AlgorithmTest {
 	
 	@Test
 	public void testComputeDistances() {
-		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), null, null, 0, 1);
+		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), 0, null, null, 0, 1);
 		
 		Solution solution1 = TestUtils.newSolution(0.0, 1.0);
 		Solution solution2 = TestUtils.newSolution(1.0, 0.0);
@@ -94,7 +94,7 @@ public class SPEA2Test extends AlgorithmTest {
 	
 	@Test
 	public void testTruncate1() {
-		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), null, null, 0, 1);
+		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), 0, null, null, 0, 1);
 		
 		Solution solution1 = TestUtils.newSolution(0.0, 1.0);
 		Solution solution2 = TestUtils.newSolution(1.0, 0.0);
@@ -116,7 +116,7 @@ public class SPEA2Test extends AlgorithmTest {
 	
 	@Test
 	public void testTruncate2() {
-		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), null, null, 0, 1);
+		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), 0, null, null, 0, 1);
 		
 		Solution solution1 = TestUtils.newSolution(0.0, 1.0);
 		Solution solution2 = TestUtils.newSolution(1.0, 0.0);
@@ -137,7 +137,7 @@ public class SPEA2Test extends AlgorithmTest {
 	
 	@Test
 	public void testFitnessNondominated() {
-		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), null, null, 0, 1);
+		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), 0, null, null, 0, 1);
 		
 		Solution solution1 = TestUtils.newSolution(0.0, 1.0);
 		Solution solution2 = TestUtils.newSolution(1.0, 0.0);
@@ -157,7 +157,7 @@ public class SPEA2Test extends AlgorithmTest {
 	
 	@Test
 	public void testFitnessDominated() {
-		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), null, null, 0, 1);
+		SPEA2 spea2 = new SPEA2(new MockRealProblem(2), 0, null, null, 0, 1);
 		
 		Solution solution1 = TestUtils.newSolution(0.0, 0.0);
 		Solution solution2 = TestUtils.newSolution(1.0, 1.0);
@@ -187,7 +187,8 @@ public class SPEA2Test extends AlgorithmTest {
 	public void testLargeK() {
 		Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");
 		SPEA2 spea2 = new SPEA2(problem,
-				new RandomInitialization(problem, 100),
+				100,
+				new RandomInitialization(problem),
 				OperatorFactory.getInstance().getVariation(null, new TypedProperties(), problem),
 				0,
 				10000);

--- a/test/org/moeaframework/core/indicator/IndicatorTest.java
+++ b/test/org/moeaframework/core/indicator/IndicatorTest.java
@@ -66,8 +66,8 @@ public abstract class IndicatorTest {
 	protected NondominatedPopulation generateApproximationSet(
 			String problemName, int N) {
 		Problem problem = ProblemFactory.getInstance().getProblem(problemName);
-		Initialization initialization = new RandomInitialization(problem, N);
-		Solution[] solutions = initialization.initialize();
+		Initialization initialization = new RandomInitialization(problem);
+		Solution[] solutions = initialization.initialize(N);
 
 		for (Solution solution : solutions) {
 			problem.evaluate(solution);

--- a/test/org/moeaframework/core/operator/InjectedInitializationTest.java
+++ b/test/org/moeaframework/core/operator/InjectedInitializationTest.java
@@ -32,9 +32,9 @@ public class InjectedInitializationTest {
 		Solution solution = problem.newSolution();
 		
 		InjectedInitialization initialization = new InjectedInitialization(
-				problem, 100, solution);
+				problem, solution);
 		
-		Solution[] solutions = initialization.initialize();
+		Solution[] solutions = initialization.initialize(100);
 		boolean found = false;
 		
 		for (Solution s : solutions) {

--- a/test/org/moeaframework/core/operator/RandomInitializationTest.java
+++ b/test/org/moeaframework/core/operator/RandomInitializationTest.java
@@ -69,8 +69,8 @@ public class RandomInitializationTest {
 
 		};
 
-		Initialization initialization = new RandomInitialization(problem, 100);
-		Assert.assertEquals(100, initialization.initialize().length);
+		Initialization initialization = new RandomInitialization(problem);
+		Assert.assertEquals(100, initialization.initialize(100).length);
 	}
 
 }

--- a/test/org/moeaframework/core/spi/OperatorFactoryTest.java
+++ b/test/org/moeaframework/core/spi/OperatorFactoryTest.java
@@ -65,9 +65,8 @@ public class OperatorFactoryTest {
 	}
 	
 	private void test(Variation variation) {
-		RandomInitialization initialization = new RandomInitialization(problem, 
-				variation.getArity());
-		Solution[] parents = initialization.initialize();
+		RandomInitialization initialization = new RandomInitialization(problem);
+		Solution[] parents = initialization.initialize(variation.getArity());
 		Solution[] offspring = variation.evolve(parents);
 		
 		Assert.assertNotNull(offspring);

--- a/test/org/moeaframework/core/spi/TestAlgorithmProvider.java
+++ b/test/org/moeaframework/core/spi/TestAlgorithmProvider.java
@@ -31,9 +31,10 @@ public class TestAlgorithmProvider extends AlgorithmProvider {
 		if (name.equalsIgnoreCase("testAlgorithm")) {
 			return new AbstractEvolutionaryAlgorithm(
 					problem,
+					100,
 					new Population(),
 					null,
-					new RandomInitialization(problem, 100),
+					new RandomInitialization(problem),
 					OperatorFactory.getInstance().getVariation(problem)) {
 
 				@Override

--- a/test/org/moeaframework/problem/CEC2009/UF11Test.java
+++ b/test/org/moeaframework/problem/CEC2009/UF11Test.java
@@ -29,10 +29,9 @@ public class UF11Test {
 	@Test
 	public void test() {
 		UF11 uf11 = new UF11();
-		RandomInitialization initialization = new RandomInitialization(uf11, 
-				TestThresholds.SAMPLES);
+		RandomInitialization initialization = new RandomInitialization(uf11);
 		
-		for (Solution solution : initialization.initialize()) {
+		for (Solution solution : initialization.initialize(TestThresholds.SAMPLES)) {
 			double[] x = EncodingUtils.getReal(solution);
 			double[] f = new double[uf11.getNumberOfObjectives()];
 			

--- a/test/org/moeaframework/problem/CEC2009/UF12Test.java
+++ b/test/org/moeaframework/problem/CEC2009/UF12Test.java
@@ -29,10 +29,9 @@ public class UF12Test {
 	@Test
 	public void test() {
 		UF12 uf12 = new UF12();
-		RandomInitialization initialization = new RandomInitialization(uf12, 
-				TestThresholds.SAMPLES);
+		RandomInitialization initialization = new RandomInitialization(uf12);
 		
-		for (Solution solution : initialization.initialize()) {
+		for (Solution solution : initialization.initialize(TestThresholds.SAMPLES)) {
 			double[] x = EncodingUtils.getReal(solution);
 			double[] f = new double[uf12.getNumberOfObjectives()];
 			

--- a/test/org/moeaframework/problem/CEC2009/UF13Test.java
+++ b/test/org/moeaframework/problem/CEC2009/UF13Test.java
@@ -33,10 +33,9 @@ public class UF13Test {
 	@Test
 	public void test() {
 		UF13 uf13 = new UF13();
-		RandomInitialization initialization = new RandomInitialization(uf13, 
-				TestThresholds.SAMPLES);
+		RandomInitialization initialization = new RandomInitialization(uf13);
 		
-		for (Solution solution : initialization.initialize()) {
+		for (Solution solution : initialization.initialize(TestThresholds.SAMPLES)) {
 			double[] x = EncodingUtils.getReal(solution);
 			double[] f = new double[uf13.getNumberOfObjectives()];
 			

--- a/test/org/moeaframework/problem/ExternalProblemWithCStdioTest.java
+++ b/test/org/moeaframework/problem/ExternalProblemWithCStdioTest.java
@@ -118,10 +118,9 @@ public class ExternalProblemWithCStdioTest {
 	
 	@Test
 	public void test() throws IOException {
-		Initialization initialization = new RandomInitialization(problem, 
-				TestThresholds.SAMPLES);
+		Initialization initialization = new RandomInitialization(problem);
 
-		Solution[] solutions = initialization.initialize();
+		Solution[] solutions = initialization.initialize(TestThresholds.SAMPLES);
 		
 		for (int i=0; i<solutions.length; i++) {
 			Solution solution = solutions[i];

--- a/test/org/moeaframework/problem/ProblemTest.java
+++ b/test/org/moeaframework/problem/ProblemTest.java
@@ -71,10 +71,10 @@ public abstract class ProblemTest {
 	 * @param exactConstraints if {@code true}, require identical constraint values
 	 */
 	protected void test(Problem problemA, Problem problemB, boolean exactConstraints) {
-		RandomInitialization initialization = new RandomInitialization(problemA, 1);
+		RandomInitialization initialization = new RandomInitialization(problemA);
 		
 		for (int i = 0; i < TestThresholds.SAMPLES; i++) {
-			Solution solutionA = initialization.initialize()[0];
+			Solution solutionA = initialization.initialize(1)[0];
 			Solution solutionB = solutionA.copy();
 			
 			problemA.evaluate(solutionA);

--- a/test/org/moeaframework/problem/RotatedProblemsTest.java
+++ b/test/org/moeaframework/problem/RotatedProblemsTest.java
@@ -114,10 +114,10 @@ public class RotatedProblemsTest {
 	}
 	
 	private void assertEquals(Problem problemA, Problem problemB) {
-		Initialization initialization = new RandomInitialization(problemA, 1);
+		Initialization initialization = new RandomInitialization(problemA);
 
 		for (int i=0; i<TestThresholds.SAMPLES; i++) {
-			Solution solutionA = initialization.initialize()[0];
+			Solution solutionA = initialization.initialize(1)[0];
 			Solution solutionB = solutionA.copy();
 			
 			problemA.evaluate(solutionA);
@@ -130,10 +130,10 @@ public class RotatedProblemsTest {
 	}
 	
 	private void assertNotEquals(Problem problemA, Problem problemB) {
-		Initialization initialization = new RandomInitialization(problemA, 1);
+		Initialization initialization = new RandomInitialization(problemA);
 
 		for (int i=0; i<TestThresholds.SAMPLES; i++) {
-			Solution solutionA = initialization.initialize()[0];
+			Solution solutionA = initialization.initialize(1)[0];
 			Solution solutionB = solutionA.copy();
 			
 			problemA.evaluate(solutionA);


### PR DESCRIPTION
Adds new `configuration` package to assist in configuring algorithms.  It works as follows:

1. Any configurable classes must implement the `Configurable` interface
2. All configurable properties must have accessible (i.e., public) getter and setter methods
3. Add the `@Property` annotation to the setter.  It infers the property name from the method name but one can also be provided explicitly (e.g., `@Property("propertyName")`).
4. Recursively process any fields that are also `Configurable`.  These must have a public getter method.
5. If there's any additional logic needed beyond getters / setters, one can also override the methods on the `Configurable` interface.  Be sure to call `super`.

This enables two new features:

1. Reading the current configuration of an algorithm:
    ```java
    TypedProperties properties = algorithm.getConfiguration();
    ```
2. Loading a configuration.  This will eventually replace the factory classes.
    ```java
    algorithm.applyConfiguration(properties);
    ```

I intend to expand this to allow one to discover the properties at runtime.  This would include information about the property type, lower / upper bounds, etc.  This could, for example, be used to display a property editor in a UI.

:warning: **Breaking Change** :warning:

This changes the `Initialization` interface.  The `initialize()` method now takes a single argument, the initial population size, `initialize(int size)`.  The population size is no longer passed into the constructor.