### PR TITLE
Allow null variation operator in constructor

### DIFF
--- a/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
@@ -86,8 +86,11 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 		setInitialPopulationSize(initialPopulationSize);
 		setPopulation(population);
 		setArchive(archive);
-		setVariation(variation);
 		setInitialization(initialization);
+		
+		if (variation != null) {
+			setVariation(variation);
+		}
 	}
 
 	@Override

--- a/src/org/moeaframework/algorithm/MOEAD.java
+++ b/src/org/moeaframework/algorithm/MOEAD.java
@@ -204,9 +204,12 @@ public class MOEAD extends AbstractAlgorithm implements Configurable {
 		setDelta(delta);
 		setEta(eta);
 		setUpdateUtility(updateUtility);
-		setVariation(variation);
 		setInitialization(initialization);
 		setWeightGenerator(weightGenerator);
+		
+		if (variation != null) {
+			setVariation(variation);
+		}
 	}
 	
 	/**

--- a/test/org/moeaframework/ExecutorTest.java
+++ b/test/org/moeaframework/ExecutorTest.java
@@ -22,8 +22,10 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.spi.AlgorithmFactoryTestWrapper;
 import org.moeaframework.core.spi.ProblemFactoryTestWrapper;
+import org.moeaframework.problem.MockMultiTypeProblem;
 
 /**
  * Tests the {@link Executor} class.
@@ -133,6 +135,25 @@ public class ExecutorTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testNoAlgorithm() {
 		new Executor().withProblem("DTLZ2_2").run();
+	}
+	
+	@Test(expected = FrameworkException.class)
+	public void testMixedTypesNoVariationOperator() {
+		new Executor()
+			.withProblem(new MockMultiTypeProblem())
+			.withAlgorithm("NSGAII")
+			.withMaxEvaluations(1000)
+			.run();
+	}
+	
+	@Test
+	public void testMixedTypes() {
+		new Executor()
+			.withProblem(new MockMultiTypeProblem())
+			.withAlgorithm("NSGAII")
+			.withProperty("operator", "2x")
+			.withMaxEvaluations(1000)
+			.run();
 	}
 	
 }


### PR DESCRIPTION
Calling an algorithm constructor with a `null` variation operator will result in a validation error, but this can happen if the variation operator can not be determined (mixed decision variable types, new types, etc.).  In such cases, the user will need to explicitly set the variation operator, but this is failing before they get a chance to.

With this change, the constructor will succeed allowing the variation operator to be configured at a later point.  It will fail, however, when attempting to initialize the algorithm (such as calling `.step()` or `run()`) if the variation operator was never set.

Fixes https://github.com/MOEAFramework/MOEAFramework/issues/359