### PR TITLE
Add population normalization

### DIFF
--- a/src/org/moeaframework/core/indicator/R1Indicator.java
+++ b/src/org/moeaframework/core/indicator/R1Indicator.java
@@ -101,7 +101,7 @@ public class R1Indicator extends RIndicator {
 			double max1 = Double.NEGATIVE_INFINITY;
 			double max2 = Double.NEGATIVE_INFINITY;
 			
-			for (Solution solution : population) {
+			for (Solution solution : normalize(population)) {
 				max1 = Math.max(max1, utilityFunction.computeUtility(solution,
 						weights[i]));
 			}

--- a/src/org/moeaframework/core/indicator/R2Indicator.java
+++ b/src/org/moeaframework/core/indicator/R2Indicator.java
@@ -65,7 +65,7 @@ public class R2Indicator extends RIndicator {
 	@Override
 	public double evaluate(NondominatedPopulation population) {
 		return expectedUtility(
-				getNormalizedReferenceSet()) - expectedUtility(population);
+				getNormalizedReferenceSet()) - expectedUtility(normalize(population));
 	}
 
 }

--- a/src/org/moeaframework/core/indicator/R3Indicator.java
+++ b/src/org/moeaframework/core/indicator/R3Indicator.java
@@ -69,7 +69,7 @@ public class R3Indicator extends RIndicator {
 			double max1 = Double.NEGATIVE_INFINITY;
 			double max2 = Double.NEGATIVE_INFINITY;
 			
-			for (Solution solution : population) {
+			for (Solution solution : normalize(population)) {
 				max1 = Math.max(max1, utilityFunction.computeUtility(solution,
 						weights[i]));
 			}


### PR DESCRIPTION
R indicators (`R1Indicator`,`R2Indicator` and `R3Indicator`) do not normalize input approximation set, but normalize reference set. Other normalized indicators normalize both. I guess, R indicators should do it as well to be consistent with the other ones.