### PR TITLE
Replace getState and setState with Stateful interface

### DIFF
--- a/src/org/moeaframework/algorithm/AbstractAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractAlgorithm.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import org.moeaframework.core.Algorithm;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.Stateful;
 import org.moeaframework.core.configuration.Validate;
 
 /**
@@ -211,7 +212,7 @@ public abstract class AbstractAlgorithm implements Algorithm {
 			throw new AlgorithmInitializationException(this, "algorithm not initialized");
 		}
 		
-		stream.writeObject(getClass().getCanonicalName());
+		Stateful.writeTypeSafety(stream, this);
 		stream.writeInt(numberOfEvaluations);
 	}
 
@@ -220,13 +221,7 @@ public abstract class AbstractAlgorithm implements Algorithm {
 		assertNotInitialized();
 		initialized = true;
 		
-		String className = (String)stream.readObject();
-		
-		if (className != null && !className.equals(getClass().getCanonicalName())) {
-			throw new IOException("attempting to restore state of " + getClass().getCanonicalName() +
-					" with data from " + className);
-		}
-		
+		Stateful.checkTypeSafety(stream, this);
 		numberOfEvaluations = stream.readInt();
 	}
 

--- a/src/org/moeaframework/algorithm/AbstractAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractAlgorithm.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
 
 import org.moeaframework.core.Algorithm;
@@ -203,15 +204,30 @@ public abstract class AbstractAlgorithm implements Algorithm {
 
 		terminated = true;
 	}
-
+	
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		throw new NotSerializableException(getClass().getName());
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		if (!isInitialized()) {
+			throw new AlgorithmInitializationException(this, "algorithm not initialized");
+		}
+		
+		stream.writeObject(getClass().getCanonicalName());
+		stream.writeInt(numberOfEvaluations);
 	}
 
 	@Override
-	public void setState(Object state) throws NotSerializableException {
-		throw new NotSerializableException(getClass().getName());
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		assertNotInitialized();
+		initialized = true;
+		
+		String className = (String)stream.readObject();
+		
+		if (className != null && !className.equals(getClass().getCanonicalName())) {
+			throw new IOException("attempting to restore state of " + getClass().getCanonicalName() +
+					" with data from " + className);
+		}
+		
+		numberOfEvaluations = stream.readInt();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
+++ b/src/org/moeaframework/algorithm/AbstractEvolutionaryAlgorithm.java
@@ -17,10 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.moeaframework.core.EvolutionaryAlgorithm;
 import org.moeaframework.core.FrameworkException;
@@ -218,112 +217,25 @@ public abstract class AbstractEvolutionaryAlgorithm extends AbstractAlgorithm
 		Validate.notNull("initialization", initialization);
 		this.initialization = initialization;
 	}
-
+	
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		if (!isInitialized()) {
-			throw new AlgorithmInitializationException(this, "algorithm not initialized");
-		}
-
-		List<Solution> populationList = new ArrayList<Solution>();
-		List<Solution> archiveList = new ArrayList<Solution>();
-
-		for (Solution solution : population) {
-			populationList.add(solution);
-		}
-
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		population.saveState(stream);
+		
 		if (archive != null) {
-			for (Solution solution : archive) {
-				archiveList.add(solution);
-			}
+			archive.saveState(stream);
 		}
-
-		return new EvolutionaryAlgorithmState(getNumberOfEvaluations(),
-				populationList, archiveList);
 	}
 
 	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		super.initialize();
-
-		EvolutionaryAlgorithmState state = (EvolutionaryAlgorithmState)objState;
-
-		numberOfEvaluations = state.getNumberOfEvaluations();
-		population.addAll(state.getPopulation());
-
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		population.loadState(stream);
+		
 		if (archive != null) {
-			archive.addAll(state.getArchive());
+			archive.loadState(stream);
 		}
-	}
-
-	/**
-	 * Proxy for serializing and deserializing the state of an
-	 * {@code AbstractEvolutionaryAlgorithm}. This proxy supports saving
-	 * the {@code numberOfEvaluations}, {@code population} and {@code archive}.
-	 */
-	private static class EvolutionaryAlgorithmState implements Serializable {
-
-		private static final long serialVersionUID = -6186688380313335557L;
-
-		/**
-		 * The number of objective function evaluations.
-		 */
-		private final int numberOfEvaluations;
-
-		/**
-		 * The population stored in a serializable list.
-		 */
-		private final List<Solution> population;
-
-		/**
-		 * The archive stored in a serializable list.
-		 */
-		private final List<Solution> archive;
-
-		/**
-		 * Constructs a proxy to serialize and deserialize the state of an 
-		 * {@code AbstractEvolutionaryAlgorithm}.
-		 * 
-		 * @param numberOfEvaluations the number of objective function
-		 *        evaluations
-		 * @param population the population stored in a serializable list
-		 * @param archive the archive stored in a serializable list
-		 */
-		public EvolutionaryAlgorithmState(int numberOfEvaluations,
-				List<Solution> population, List<Solution> archive) {
-			super();
-			this.numberOfEvaluations = numberOfEvaluations;
-			this.population = population;
-			this.archive = archive;
-		}
-
-		/**
-		 * Returns the number of objective function evaluations.
-		 * 
-		 * @return the number of objective function evaluations
-		 */
-		public int getNumberOfEvaluations() {
-			return numberOfEvaluations;
-		}
-
-		/**
-		 * Returns the population stored in a serializable list.
-		 * 
-		 * @return the population stored in a serializable list
-		 */
-		public List<Solution> getPopulation() {
-			return population;
-		}
-
-		/**
-		 * Returns the archive stored in a serializable list.
-		 * 
-		 * @return the archive stored in a serializable list
-		 */
-		public List<Solution> getArchive() {
-			return archive;
-		}
-
 	}
 
 }

--- a/src/org/moeaframework/algorithm/AdaptiveTimeContinuation.java
+++ b/src/org/moeaframework/algorithm/AdaptiveTimeContinuation.java
@@ -17,9 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
-
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.apache.commons.lang3.event.EventListenerSupport;
 import org.moeaframework.core.EvolutionaryAlgorithm;
 import org.moeaframework.core.NondominatedPopulation;
@@ -354,74 +354,16 @@ public class AdaptiveTimeContinuation extends PeriodicAction implements Evolutio
 		return getAlgorithm().getArchive();
 	}
 	
-	/**
-	 * Proxy for serializing and deserializing the state of an
-	 * {@code AdaptiveTimeContinuation} instance. This proxy supports saving
-	 * the underlying algorithm state and {@code iterationAtLastRestart}.
-	 */
-	private static class AdaptiveTimeContinuationState implements Serializable {
-
-		private static final long serialVersionUID = -4773227519517581809L;
-
-		/**
-		 * The state of the underlying algorithm.
-		 */
-		private final Serializable algorithmState;
-		
-		/**
-		 * The {@code iterationAtLastRestart} value of the
-		 * {@code AdaptiveTimeContinuation} instance.
-		 */
-		private final int iterationAtLastRestart;
-
-		/**
-		 * Constructs a proxy for storing the state of an
-		 * {@code AdaptiveTimeContinuation} instance.
-		 * 
-		 * @param algorithmState the state of the underlying algorithm
-		 * @param iterationAtLastRestart the {@code iterationAtLastRestart}
-		 *        value of the {@code AdaptiveTimeContinuation} instance
-		 */
-		public AdaptiveTimeContinuationState(Serializable algorithmState,
-				int iterationAtLastRestart) {
-			super();
-			this.algorithmState = algorithmState;
-			this.iterationAtLastRestart = iterationAtLastRestart;
-		}
-
-		/**
-		 * Returns the underlying algorithm state.
-		 * 
-		 * @return the underlying algorithm state
-		 */
-		public Serializable getAlgorithmState() {
-			return algorithmState;
-		}
-
-		/**
-		 * Returns the {@code iterationAtLastRestart} value of the
-		 * {@code AdaptiveTimeContinuation} instance.
-		 * 
-		 * @return the {@code iterationAtLastRestart} value of the
-		 *         {@code AdaptiveTimeContinuation} instance
-		 */
-		public int getIterationAtLastRestart() {
-			return iterationAtLastRestart;
-		}
-		
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeInt(iterationAtLastRestart);
 	}
 
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		return new AdaptiveTimeContinuationState(super.getState(), iterationAtLastRestart);
-	}
-
-	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		AdaptiveTimeContinuationState state = (AdaptiveTimeContinuationState)objState;
-		
-		super.setState(state.getAlgorithmState());
-		iterationAtLastRestart = state.getIterationAtLastRestart();
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		iterationAtLastRestart = stream.readInt();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/CMAES.java
+++ b/src/org/moeaframework/algorithm/CMAES.java
@@ -33,6 +33,7 @@ import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.Stateful;
 import org.moeaframework.core.comparator.AggregateConstraintComparator;
 import org.moeaframework.core.comparator.ChainedComparator;
 import org.moeaframework.core.comparator.FitnessComparator;
@@ -1183,7 +1184,7 @@ public class CMAES extends AbstractAlgorithm implements Configurable {
 	
 	@Override
 	public void saveState(ObjectOutputStream stream) throws IOException {
-		stream.writeObject(getClass().getCanonicalName());
+		Stateful.writeTypeSafety(stream, this);
 		stream.writeInt(numberOfEvaluations);
 		stream.writeObject(xmean);
 		stream.writeInt(iteration);
@@ -1203,13 +1204,7 @@ public class CMAES extends AbstractAlgorithm implements Configurable {
 
 	@Override
 	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
-		String className = (String)stream.readObject();
-		
-		if (className != null && !className.equals(getClass().getCanonicalName())) {
-			throw new IOException("attempting to restore state of " + getClass().getCanonicalName() +
-					" with data from " + className);
-		}
-		
+		Stateful.checkTypeSafety(stream, this);
 		numberOfEvaluations = stream.readInt();
 		xmean = (double[])stream.readObject();
 		

--- a/src/org/moeaframework/algorithm/Checkpoints.java
+++ b/src/org/moeaframework/algorithm/Checkpoints.java
@@ -27,6 +27,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.moeaframework.core.Algorithm;
+import org.moeaframework.util.io.FileUtils;
 
 /**
  * Decorates an {@link Algorithm} to periodically save checkpoint files from
@@ -58,8 +59,7 @@ public class Checkpoints extends PeriodicAction {
 	 * @param checkpointFrequency the number of objective function evaluations
 	 *        between checkpoints
 	 */
-	public Checkpoints(Algorithm algorithm, File stateFile,
-			int checkpointFrequency) {
+	public Checkpoints(Algorithm algorithm, File stateFile, int checkpointFrequency) {
 		super(algorithm, checkpointFrequency, FrequencyType.EVALUATIONS);
 		this.stateFile = stateFile;
 
@@ -68,8 +68,7 @@ public class Checkpoints extends PeriodicAction {
 				loadFromStateFile();
 			} catch (Exception e) {
 				e.printStackTrace();
-				System.err.println(
-						"an error occurred while reading the state file");
+				System.err.println("an error occurred while reading the state file");
 			}
 		}
 	}
@@ -81,10 +80,14 @@ public class Checkpoints extends PeriodicAction {
 	 * @throws IOException if an I/O error occurred
 	 */
 	private void saveToStateFile() throws IOException {
+		File tempFile = File.createTempFile("checkpoint", "state");
+		
 		try (ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(
-					new FileOutputStream(stateFile)))) {
+					new FileOutputStream(tempFile)))) {
 			algorithm.saveState(oos);
 		}
+		
+		FileUtils.move(tempFile, stateFile);
 	}
 
 	/**
@@ -92,8 +95,7 @@ public class Checkpoints extends PeriodicAction {
 	 * 
 	 * @return the state
 	 * @throws IOException if an I/O error occurred
-	 * @throws ClassNotFoundException if the class of a serialized object could
-	 *         not be found.
+	 * @throws ClassNotFoundException if the class of a serialized object could not be found.
 	 */
 	private void loadFromStateFile() throws IOException, ClassNotFoundException {
 		try (ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(
@@ -107,8 +109,7 @@ public class Checkpoints extends PeriodicAction {
 		try {
 			saveToStateFile();
 		} catch (IOException e) {
-			System.err.println(
-					"an error occurred while writing the state file");
+			System.err.println("an error occurred while writing the state file");
 		}
 	}
 

--- a/src/org/moeaframework/algorithm/Checkpoints.java
+++ b/src/org/moeaframework/algorithm/Checkpoints.java
@@ -25,7 +25,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Serializable;
 
 import org.moeaframework.core.Algorithm;
 
@@ -66,7 +65,7 @@ public class Checkpoints extends PeriodicAction {
 
 		if (stateFile.exists() && (stateFile.length() != 0L)) {
 			try {
-				algorithm.setState(loadState());
+				loadFromStateFile();
 			} catch (Exception e) {
 				e.printStackTrace();
 				System.err.println(
@@ -81,10 +80,10 @@ public class Checkpoints extends PeriodicAction {
 	 * @param state the state
 	 * @throws IOException if an I/O error occurred
 	 */
-	private void saveState(Serializable state) throws IOException {
+	private void saveToStateFile() throws IOException {
 		try (ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(
 					new FileOutputStream(stateFile)))) {
-			oos.writeObject(state);
+			algorithm.saveState(oos);
 		}
 	}
 
@@ -96,17 +95,17 @@ public class Checkpoints extends PeriodicAction {
 	 * @throws ClassNotFoundException if the class of a serialized object could
 	 *         not be found.
 	 */
-	private Object loadState() throws IOException, ClassNotFoundException {
+	private void loadFromStateFile() throws IOException, ClassNotFoundException {
 		try (ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(
 					new FileInputStream(stateFile)))) {
-			return ois.readObject();
+			algorithm.loadState(ois);
 		}
 	}
 	
 	@Override
 	public void doAction() {
 		try {
-			saveState(algorithm.getState());
+			saveToStateFile();
 		} catch (IOException e) {
 			System.err.println(
 					"an error occurred while writing the state file");

--- a/src/org/moeaframework/algorithm/EpsilonProgressContinuation.java
+++ b/src/org/moeaframework/algorithm/EpsilonProgressContinuation.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.moeaframework.core.EpsilonBoxDominanceArchive;
 import org.moeaframework.core.EpsilonBoxEvolutionaryAlgorithm;
@@ -97,81 +98,19 @@ public class EpsilonProgressContinuation extends AdaptiveTimeContinuation {
 	@Override
 	protected void restart(RestartType type) {
 		super.restart(type);
-
 		improvementsAtLastCheck = getArchive().getNumberOfImprovements();
 	}
 	
-	/**
-	 * Proxy for serializing and deserializing the state of an
-	 * {@code EpsilonProgressContinuation} instance. This proxy supports saving
-	 * the underlying algorithm state and {@code improvementsAtLastCheck}.
-	 */
-	private static class EpsilonProgressContinuationState implements
-	Serializable {
-
-		private static final long serialVersionUID = -4773227519517581809L;
-
-		/**
-		 * The state of the underlying algorithm.
-		 */
-		private final Serializable algorithmState;
-		
-		/**
-		 * The {@code improvementsAtLastCheck} value of the
-		 * {@code EpsilonProgressContinuation} instance.
-		 */
-		private final int improvementsAtLastCheck;
-
-		/**
-		 * Constructs a proxy for storing the state of an
-		 * {@code EpsilonProgressContinuation} instance.
-		 * 
-		 * @param algorithmState the state of the underlying algorithm
-		 * @param improvementsAtLastCheck the {@code improvementsAtLastCheck}
-		 *        value of the {@code EpsilonProgressContinuation} instance
-		 */
-		public EpsilonProgressContinuationState(Serializable algorithmState,
-				int improvementsAtLastCheck) {
-			super();
-			this.algorithmState = algorithmState;
-			this.improvementsAtLastCheck = improvementsAtLastCheck;
-		}
-
-		/**
-		 * Returns the underlying algorithm state.
-		 * 
-		 * @return the underlying algorithm state
-		 */
-		public Serializable getAlgorithmState() {
-			return algorithmState;
-		}
-
-		/**
-		 * Returns the {@code improvementsAtLastCheck} value of the
-		 * {@code EpsilonProgressContinuation} instance.
-		 * 
-		 * @return the {@code improvementsAtLastCheck} value of the
-		 *         {@code EpsilonProgressContinuation} instance
-		 */
-		public int getImprovementsAtLastCheck() {
-			return improvementsAtLastCheck;
-		}
-		
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeInt(improvementsAtLastCheck);
 	}
 
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		return new EpsilonProgressContinuationState(super.getState(),
-				improvementsAtLastCheck);
-	}
-
-	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		EpsilonProgressContinuationState state =
-				(EpsilonProgressContinuationState)objState;
-		
-		super.setState(state.getAlgorithmState());
-		improvementsAtLastCheck = state.getImprovementsAtLastCheck();
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		improvementsAtLastCheck = stream.readInt();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/MOEAD.java
+++ b/src/org/moeaframework/algorithm/MOEAD.java
@@ -17,7 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -876,111 +878,21 @@ public class MOEAD extends AbstractAlgorithm implements Configurable {
 
 	}
 	
-	/**
-	 * Proxy for serializing and deserializing the state of a {@code MOEAD} instance. This proxy supports saving
-	 * the {@code population}, {@code idealPoint} and {@code generation}.
-	 */
-	private static class MOEADState implements Serializable {
-
-		private static final long serialVersionUID = 8694911146929397897L;
-
-		/**
-		 * The {@code population} from the {@code MOEAD} instance.
-		 */
-		private final List<Individual> population;
-		
-		/**
-		 * The value of the {@code idealPoint} from the {@code MOEAD} instance.
-		 */
-		private final double[] idealPoint;
-		
-		/**
-		 * The value of {@code numberOfEvaluations} from the {@code MOEAD}
-		 * instance.
-		 */
-		private final int numberOfEvaluations;
-		
-		/**
-		 * The value of {@code generation} from the {@code MOEAD} instance.
-		 */
-		private final int generation;
-		
-		/**
-		 * Constructs a proxy for serializing and deserializing the state of a {@code MOEAD} instance.
-		 * 
-		 * @param population the {@code population} from the {@code MOEAD} instance
-		 * @param idealPoint the value of the {@code idealPoint} from the {@code MOEAD} instance
-		 * @param numberOfEvaluations the value of {@code numberOfEvaluations} from the {@code MOEAD} instance
-		 * @param generation the value of {@code generation} from the {@code MOEAD} instance
-		 */
-		public MOEADState(List<Individual> population, double[] idealPoint,
-				int numberOfEvaluations, int generation) {
-			super();
-			this.population = population;
-			this.idealPoint = idealPoint;
-			this.numberOfEvaluations = numberOfEvaluations;
-			this.generation = generation;
-		}
-
-		/**
-		 * Returns the {@code population} from the {@code MOEAD} instance.
-		 * 
-		 * @return the {@code population} from the {@code MOEAD} instance
-		 */
-		public List<Individual> getPopulation() {
-			return population;
-		}
-
-		/**
-		 * Returns the value of the {@code idealPoint} from the {@code MOEAD}
-		 * instance.
-		 * 
-		 * @return the value of the {@code idealPoint} from the {@code MOEAD}
-		 *         instance
-		 */
-		public double[] getIdealPoint() {
-			return idealPoint;
-		}
-		
-		/**
-		 * Returns the value of {@code numberOfEvaluations} from the
-		 * {@code MOEAD} instance.
-		 * 
-		 * @return the value of {@code numberOfEvaluations} from the
-		 *         {@code MOEAD} instance
-		 */
-		public int getNumberOfEvaluations() {
-			return numberOfEvaluations;
-		}
-
-		/**
-		 * Returns the value of {@code generation} from the {@code MOEAD}
-		 * instance.
-		 * 
-		 * @return the value of {@code generation} from the {@code MOEAD}
-		 *         instance
-		 */
-		public int getGeneration() {
-			return generation;
-		}
-		
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeObject(population);
+		stream.writeObject(idealPoint);
+		stream.writeInt(generation);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		return new MOEADState(population, idealPoint, numberOfEvaluations, generation);
-	}
-
-	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		super.initialize();
-
-		MOEADState state = (MOEADState)objState;
-
-		population = state.getPopulation();
-		idealPoint = state.getIdealPoint();
-		numberOfEvaluations = state.getNumberOfEvaluations();
-		generation = state.getGeneration();
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		population = (List<Individual>)stream.readObject();
+		idealPoint = (double[])stream.readObject();
+		generation = stream.readInt();
 	}
 	
 }

--- a/src/org/moeaframework/algorithm/MSOPS.java
+++ b/src/org/moeaframework/algorithm/MSOPS.java
@@ -114,9 +114,6 @@ public class MSOPS extends AbstractEvolutionaryAlgorithm {
 		return (DifferentialEvolutionVariation)super.getVariation();
 	}
 	
-	/**
-	 * {@inheritDoc}
-	 */
 	@Property("operator")
 	public void setVariation(DifferentialEvolutionVariation variation) {
 		super.setVariation(variation);

--- a/src/org/moeaframework/algorithm/MSOPSRankedPopulation.java
+++ b/src/org/moeaframework/algorithm/MSOPSRankedPopulation.java
@@ -19,6 +19,8 @@ package org.moeaframework.algorithm;
 
 import static org.moeaframework.core.FastNondominatedSorting.RANK_ATTRIBUTE;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -368,6 +370,12 @@ public class MSOPSRankedPopulation extends Population {
 		for (int i = 0; i < P; i++) {
 			get(indices[i]).setAttribute(RANK_ATTRIBUTE, i);
 		}
+	}
+	
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		update();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/MSOPSRankedPopulation.java
+++ b/src/org/moeaframework/algorithm/MSOPSRankedPopulation.java
@@ -21,6 +21,7 @@ import static org.moeaframework.core.FastNondominatedSorting.RANK_ATTRIBUTE;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -373,9 +374,24 @@ public class MSOPSRankedPopulation extends Population {
 	}
 	
 	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeObject(weights);
+		stream.writeObject(scores);
+		stream.writeObject(ranks);
+		stream.writeObject(sortedRanks);
+		stream.writeBoolean(modified);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
 	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 		super.loadState(stream);
-		update();
+		weights = (List<double[]>)stream.readObject();
+		scores = (double[][])stream.readObject();
+		ranks = (int[][])stream.readObject();
+		sortedRanks = (int[][])stream.readObject();
+		modified = stream.readBoolean();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/PeriodicAction.java
+++ b/src/org/moeaframework/algorithm/PeriodicAction.java
@@ -17,9 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
-
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.moeaframework.core.Algorithm;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
@@ -161,92 +161,18 @@ public abstract class PeriodicAction implements Algorithm {
 	 */
 	public abstract void doAction();
 	
-	/**
-	 * Proxy for serializing and deserializing the state of a
-	 * {@code PeriodicAction}. This proxy supports saving
-	 * the underlying algorithm state, {@code iteration} and
-	 * {@code lastInvocation}.
-	 */
-	private static class PeriodicActionState implements Serializable {
-
-		private static final long serialVersionUID = -8654866332843263225L;
-
-		/**
-		 * The state of the underlying algorithm.
-		 */
-		private final Serializable algorithmState;
-		
-		/**
-		 * The {@code iteration} value of the {@code PeriodicAction}.
-		 */
-		private final int iteration;
-
-		/**
-		 * The {@code lastInvocation} value of the {@code PeriodicAction}.
-		 */
-		private final int lastInvocation;
-		
-		/**
-		 * Constructs a proxy for storing the state of a {@code PeriodicAction}.
-		 * 
-		 * @param algorithmState the state of the underlying algorithm
-		 * @param iteration the {@code iteration} value of the
-		 *        {@code PeriodicAction}
-		 * @param lastInvocation the {@code lastInvocation} value of the
-		 *        {@code PeriodicAction}
-		 */
-		public PeriodicActionState(Serializable algorithmState, int iteration,
-				int lastInvocation) {
-			super();
-			this.algorithmState = algorithmState;
-			this.iteration = iteration;
-			this.lastInvocation = lastInvocation;
-		}
-
-		/**
-		 * Returns the underlying algorithm state.
-		 * 
-		 * @return the underlying algorithm state
-		 */
-		public Serializable getAlgorithmState() {
-			return algorithmState;
-		}
-
-		/**
-		 * Returns the {@code iteration} value of the {@code PeriodicAction}.
-		 * 
-		 * @return the {@code iteration} value of the {@code PeriodicAction}
-		 */
-		public int getIteration() {
-			return iteration;
-		}
-
-		/**
-		 * Returns the {@code lastInvocation} value of the
-		 * {@code PeriodicAction}.
-		 * 
-		 * @return the {@code lastInvocation} value of the
-		 *         {@code PeriodicAction}
-		 */
-		public int getLastInvocation() {
-			return lastInvocation;
-		}
-		
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		algorithm.saveState(stream);
+		stream.writeInt(iteration);
+		stream.writeInt(lastInvocation);
 	}
 
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		return new PeriodicActionState(algorithm.getState(), iteration,
-				lastInvocation);
-	}
-
-	@Override
-	public void setState(Object state) throws NotSerializableException {
-		PeriodicActionState periodicActionState = (PeriodicActionState)state;
-		
-		algorithm.setState(periodicActionState.getAlgorithmState());
-		iteration = periodicActionState.getIteration();
-		lastInvocation = periodicActionState.getLastInvocation();
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		algorithm.loadState(stream);
+		iteration = stream.readInt();
+		lastInvocation = stream.readInt();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/RVEA.java
+++ b/src/org/moeaframework/algorithm/RVEA.java
@@ -17,12 +17,12 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.moeaframework.algorithm.ReferenceVectorGuidedPopulation.ReferenceVectorGuidedPopulationState;
 import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.Initialization;
 import org.moeaframework.core.PRNG;
@@ -247,91 +247,17 @@ public class RVEA extends AbstractEvolutionaryAlgorithm {
 	}
 	
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		if (!isInitialized()) {
-			throw new AlgorithmInitializationException(this, "algorithm not initialized");
-		}
-
-		return new RVEAState(getNumberOfEvaluations(), generation, getPopulation().getState());
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeInt(generation);
+		getPopulation().saveState(stream);
 	}
 
 	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		RVEAState state = (RVEAState)objState;
-
-		initialized = true;
-		numberOfEvaluations = state.getNumberOfEvaluations();
-		generation = state.getGeneration();
-		getPopulation().setState(state.getPopulationState());
-	}
-
-	/**
-	 * Proxy for serializing and deserializing the state of an
-	 * {@code RVEA} instance. This proxy supports saving
-	 * the {@code numberOfEvaluations}, {@code generation}, {@code population}
-	 * and {@code archive}.
-	 */
-	private static class RVEAState implements Serializable {
-
-		private static final long serialVersionUID = 5341464818762163296L;
-
-		/**
-		 * The number of objective function evaluations.
-		 */
-		private final int numberOfEvaluations;
-		
-		/**
-		 * The current generation.
-		 */
-		private final int generation;
-
-		/**
-		 * The population stored in a serializable list.
-		 */
-		private final ReferenceVectorGuidedPopulationState populationState;
-
-		/**
-		 * Constructs a proxy to serialize and deserialize the state of an 
-		 * {@code RVEA} instance.
-		 * 
-		 * @param numberOfEvaluations the number of objective function evaluations
-		 * @param generation the current generation
-		 * @param population the population stored in a serializable object
-		 */
-		public RVEAState(int numberOfEvaluations, int generation, ReferenceVectorGuidedPopulationState populationState) {
-			super();
-			this.numberOfEvaluations = numberOfEvaluations;
-			this.generation = generation;
-			this.populationState = populationState;
-		}
-
-		/**
-		 * Returns the number of objective function evaluations.
-		 * 
-		 * @return the number of objective function evaluations
-		 */
-		public int getNumberOfEvaluations() {
-			return numberOfEvaluations;
-		}
-
-		/**
-		 * Returns the current generation.
-		 * 
-		 * @return the current generation
-		 */
-		public int getGeneration() {
-			return generation;
-		}
-
-		/**
-		 * Returns the population stored in a serializable object.
-		 * 
-		 * @return the population stored in a serializable object
-		 */
-		public ReferenceVectorGuidedPopulationState getPopulationState() {
-			return populationState;
-		}
-
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		generation = stream.readInt();
+		getPopulation().loadState(stream);
 	}
 
 }

--- a/src/org/moeaframework/algorithm/ReferencePointNondominatedSortingPopulation.java
+++ b/src/org/moeaframework/algorithm/ReferencePointNondominatedSortingPopulation.java
@@ -19,6 +19,9 @@ package org.moeaframework.algorithm;
 
 import static org.moeaframework.core.FastNondominatedSorting.RANK_ATTRIBUTE;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -607,6 +610,21 @@ public class ReferencePointNondominatedSortingPopulation extends NondominatedSor
 	@Override
 	public void truncate(int size) {
 		truncate(size, new RankComparator());
+	}
+	
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeObject(idealPoint);
+		stream.writeObject(weights);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		idealPoint = (double[])stream.readObject();
+		weights = (List<double[]>)stream.readObject();
 	}
 	
 }

--- a/src/org/moeaframework/algorithm/ReferenceVectorGuidedPopulation.java
+++ b/src/org/moeaframework/algorithm/ReferenceVectorGuidedPopulation.java
@@ -17,7 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -27,8 +29,8 @@ import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.Population;
 import org.moeaframework.core.Solution;
 import org.moeaframework.util.Vector;
-import org.moeaframework.util.weights.NormalBoundaryIntersectionGenerator;
 import org.moeaframework.util.weights.NormalBoundaryDivisions;
+import org.moeaframework.util.weights.NormalBoundaryIntersectionGenerator;
 
 /**
  * A reference vector guided population, for use with RVEA, that truncates
@@ -448,174 +450,23 @@ public class ReferenceVectorGuidedPopulation extends Population {
 		}
 	}
 	
-	/**
-	 * Returns the serializable state of this population.
-	 * 
-	 * @return the serializable state of this population
-	 */
-	protected ReferenceVectorGuidedPopulationState getState() {
-		double[] idealPointClone = idealPoint == null ? null : idealPoint.clone();
-		List<double[]> originalWeightsClone = new ArrayList<double[]>();
-		List<double[]> weightsClone = new ArrayList<double[]>();
-		double[] minAnglesClone = minAngles == null ? null : minAngles.clone();
-		List<Solution> populationList = new ArrayList<Solution>();
-		
-		for (double[] weight : originalWeights) {
-			originalWeightsClone.add(weight.clone());
-		}
-		
-		for (double[] weight : weights) {
-			weightsClone.add(weight.clone());
-		}
-		
-		for (Solution solution : this) {
-			populationList.add(solution);
-		}
-		
-		return new ReferenceVectorGuidedPopulationState(populationList,
-				idealPointClone, originalWeightsClone, weightsClone,
-				minAnglesClone, scalingFactor);
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeObject(idealPoint);
+		stream.writeObject(originalWeights);
+		stream.writeObject(weights);
+		stream.writeObject(minAngles);
+		stream.writeDouble(scalingFactor);
 	}
-	
-	/**
-	 * Configures this population given the serializable state.
-	 * 
-	 * @param state the serializable state
-	 */
-	protected void setState(ReferenceVectorGuidedPopulationState state) {
-		idealPoint = state.getIdealPoint() == null ? null : state.getIdealPoint().clone();
-		minAngles = state.getMinAngles() == null ? null : state.getMinAngles().clone();
-		scalingFactor = state.getScalingFactor();
-		originalWeights.clear();
-		weights.clear();
-		clear();
-		
-		for (double[] weight : state.getOriginalWeights()) {
-			originalWeights.add(weight.clone());
-		}
-		
-		for (double[] weight : state.getWeights()) {
-			weights.add(weight.clone());
-		}
-		
-		addAll(state.getPopulation());
-	}
-	
-	/**
-	 * Proxy for serializing the state of this population.  All data fields
-	 * provided to or read from this proxy should be cloned.
-	 */
-	protected static class ReferenceVectorGuidedPopulationState implements Serializable {
 
-		private static final long serialVersionUID = 2967034665150122964L;
-		
-		/**
-		 * The population stored in a serializable list.
-		 */
-		private final List<Solution> population;
-
-		/**
-		 * The ideal point.
-		 */
-		private final double[] idealPoint;
-		
-		/**
-		 * The original weight vectors.
-		 */
-		private final List<double[]> originalWeights;
-		
-		/**
-		 * The weight vectors.
-		 */
-		private final List<double[]> weights;
-		
-		/**
-		 * The minimum angles between weight vectors.
-		 */
-		private final double[] minAngles;
-		
-		/**
-		 * The scaling factor.
-		 */
-		private final double scalingFactor;
-		
-		/**
-		 * Creates a new proxy for serializing the state of this population.
-		 * 
-		 * @param population the population stored in a serializable list
-		 * @param idealPoint the ideal point
-		 * @param originalWeights the original weight vectors
-		 * @param weights the weight vectors
-		 * @param minAngles the minimum angles between weight vectors
-		 * @param scalingFactor the scaling factor
-		 */
-		public ReferenceVectorGuidedPopulationState(List<Solution> population,
-				double[] idealPoint, List<double[]> originalWeights,
-				List<double[]> weights, double[] minAngles,
-				double scalingFactor) {
-			super();
-			this.population = population;
-			this.idealPoint = idealPoint;
-			this.originalWeights = originalWeights;
-			this.weights = weights;
-			this.minAngles = minAngles;
-			this.scalingFactor = scalingFactor;
-		}
-		
-		/**
-		 * Returns the population stored in a serializable list.
-		 * 
-		 * @return the population stored in a serializable list
-		 */
-		public List<Solution> getPopulation() {
-			return population;
-		}
-
-		/**
-		 * Returns the ideal point.
-		 * 
-		 * @return the ideal point
-		 */
-		public double[] getIdealPoint() {
-			return idealPoint;
-		}
-
-		/**
-		 * Returns the original weight vectors.
-		 * 
-		 * @return the original weight vectors
-		 */
-		public List<double[]> getOriginalWeights() {
-			return originalWeights;
-		}
-
-		/**
-		 * Returns the weight vectors.
-		 * 
-		 * @return the weight vectors
-		 */
-		public List<double[]> getWeights() {
-			return weights;
-		}
-
-		/**
-		 * Returns the minimum angles between weight vectors.
-		 * 
-		 * @return the minimum angles between weight vectors
-		 */
-		public double[] getMinAngles() {
-			return minAngles;
-		}
-
-		/**
-		 * Returns the scaling factor.
-		 * 
-		 * @return the scaling factor
-		 */
-		public double getScalingFactor() {
-			return scalingFactor;
-		}
-		
+	@SuppressWarnings("unchecked")
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		idealPoint = (double[])stream.readObject();
+		originalWeights = (List<double[]>)stream.readObject();
+		weights = (List<double[]>)stream.readObject();
+		minAngles = (double[])stream.readObject();
+		scalingFactor = stream.readDouble();
 	}
 
 }

--- a/src/org/moeaframework/algorithm/sa/AMOSA.java
+++ b/src/org/moeaframework/algorithm/sa/AMOSA.java
@@ -17,12 +17,10 @@
  */
 package org.moeaframework.algorithm.sa;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
-import org.moeaframework.algorithm.AlgorithmInitializationException;
 import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
@@ -528,122 +526,25 @@ public class AMOSA extends AbstractSimulatedAnnealingAlgorithm {
 	public void setVariation(Mutation mutation) {
 		this.mutation = mutation;
 	}
-
-	@Override
-	public Serializable getState() throws NotSerializableException {
-		if (!isInitialized()) {
-			throw new AlgorithmInitializationException(this, 
-					"algorithm not initialized");
-		}
-
-		Solution current = this.currentPT;
-		List<Solution> archiveList = new ArrayList<Solution>();
-		
-		if (archive != null) {
-			for (Solution solution : archive) {
-				archiveList.add(solution);
-			}
-		}
-
-		return new AMOSAAlgorithmState(getNumberOfEvaluations(), current, archiveList, temperature);
-	}
-
-	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		super.initialize();
-		
-		AMOSAAlgorithmState state = (AMOSAAlgorithmState)objState;
-
-		numberOfEvaluations = state.getNumberOfEvaluations();
-		currentPT = state.getCurrent();
-		temperature = state.getTemperature();
-		
-		if (archive != null) {
-			archive.addAll(state.getArchive());
-		}
-	}
 	
-	/**
-	 * Proxy for serializing and deserializing the state of an
-	 * {@code AMOSAAlgorithm}. This proxy supports saving
-	 * the {@code numberOfEvaluations}, {@code current} and {@code archive}.
-	 */
-	private static class AMOSAAlgorithmState implements Serializable {
-
-		private static final long serialVersionUID = 5456685096695481165L;
-
-		/**
-		 * The number of objective function evaluations.
-		 */
-		private final int numberOfEvaluations;
-
-		/**
-		 * The current object is stored in a serializable object.
-		 */
-		private final Solution current;
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeObject(currentPT);
 		
-		/**
-		 * The temperature
-		 */
-		private final double temperature;
-
-		/**
-		 * The archive stored in a serializable list.
-		 */
-		private final List<Solution> archive;
-
-		/**
-		 * Constructs a proxy to serialize and deserialize the state of an 
-		 * {@code AbstractEvolutionaryAlgorithm}.
-		 * 
-		 * @param numberOfEvaluations the number of objective function
-		 *        evaluations
-		 * @param population the population stored in a serializable list
-		 * @param archive the archive stored in a serializable list
-		 */
-		public AMOSAAlgorithmState(int numberOfEvaluations,
-				Solution current, List<Solution> archive, double temperature) {
-			super();
-			this.numberOfEvaluations = numberOfEvaluations;
-			this.current = current;
-			this.archive = archive;
-			this.temperature = temperature;
-		}
-
-		/**
-		 * Returns the number of objective function evaluations.
-		 * 
-		 * @return the number of objective function evaluations
-		 */
-		public int getNumberOfEvaluations() {
-			return numberOfEvaluations;
-		}
-
-		/**
-		 * Returns the population stored in a serializable list.
-		 * 
-		 * @return the population stored in a serializable list
-		 */
-		public Solution getCurrent() {
-			return current;
-		}
-
-		/**
-		 * Returns the archive stored in a serializable list.
-		 * 
-		 * @return the archive stored in a serializable list
-		 */
-		public List<Solution> getArchive() {
-			return archive;
-		}
-		
-		/**
-		 * Returns the temperature.
-		 * 
-		 * @return the temperature
-		 */
-		public double getTemperature() {
-			return temperature;
+		if (archive != null) {
+			archive.saveState(stream);
 		}
 	}
+
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		currentPT = (Solution)stream.readObject();
+		
+		if (this.archive != null) {
+			archive.loadState(stream);
+		}
+	}
+
 }

--- a/src/org/moeaframework/algorithm/sa/AbstractSimulatedAnnealingAlgorithm.java
+++ b/src/org/moeaframework/algorithm/sa/AbstractSimulatedAnnealingAlgorithm.java
@@ -17,6 +17,10 @@
  */
 package org.moeaframework.algorithm.sa;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.moeaframework.algorithm.AbstractAlgorithm;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.configuration.Configurable;
@@ -105,6 +109,18 @@ public abstract class AbstractSimulatedAnnealingAlgorithm extends AbstractAlgori
 	public void setInitialTemperature(double initialTemperature) {
 		assertNotInitialized();
 		this.initialTemperature = initialTemperature;
+	}
+	
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeDouble(temperature);
+	}
+
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		temperature = stream.readDouble();
 	}
 		
 }

--- a/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
+++ b/src/org/moeaframework/algorithm/single/GeneticAlgorithm.java
@@ -17,7 +17,8 @@
  */
 package org.moeaframework.algorithm.single;
 
-import java.io.NotSerializableException;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Comparator;
 
 import org.moeaframework.core.Initialization;
@@ -156,8 +157,8 @@ public class GeneticAlgorithm extends SingleObjectiveEvolutionaryAlgorithm {
 	}
 
 	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		super.setState(objState);
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
 		
 		eliteSolution = getPopulation().get(0);
 		updateEliteSolution();

--- a/src/org/moeaframework/algorithm/single/RepeatedSingleObjective.java
+++ b/src/org/moeaframework/algorithm/single/RepeatedSingleObjective.java
@@ -17,6 +17,9 @@
  */
 package org.moeaframework.algorithm.single;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -140,6 +143,30 @@ public class RepeatedSingleObjective extends AbstractAlgorithm {
 	protected void iterate() {
 		for (Algorithm algorithm : algorithms) {
 			algorithm.step();
+		}
+	}
+	
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeInt(algorithms.size());
+		
+		for (Algorithm algorithm : algorithms) {
+			algorithm.saveState(stream);
+		}
+	}
+
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		int expectedSize = stream.readInt();
+		
+		if (algorithms.size() != expectedSize) {
+			throw new IOException("the number of instances used by RSO differs from the loaded state");
+		}
+		
+		for (Algorithm algorithm : algorithms) {
+			algorithm.loadState(stream);
 		}
 	}
 

--- a/src/org/moeaframework/analysis/collector/InstrumentedAlgorithm.java
+++ b/src/org/moeaframework/analysis/collector/InstrumentedAlgorithm.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.analysis.collector;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,12 +35,12 @@ public class InstrumentedAlgorithm extends PeriodicAction {
 	/**
 	 * The observations recorded from this algorithm.
 	 */
-	private final Observations observations;
+	private Observations observations;
 	
 	/**
 	 * The collectors responsible for recording the necessary information.
 	 */
-	private final List<Collector> collectors;
+	private List<Collector> collectors;
 
 	/**
 	 * Decorates the specified algorithm to periodically collect information
@@ -97,74 +98,16 @@ public class InstrumentedAlgorithm extends PeriodicAction {
 		observations.add(observation);
 	}
 	
-	/**
-	 * Proxy for serializing and deserializing the state of an
-	 * {@code InstrumentedAlgorithm} instance. This proxy supports saving
-	 * the underlying algorithm state and the observations.
-	 */
-	private static class InstrumentedAlgorithmState implements Serializable {
-
-		private static final long serialVersionUID = -313598408729472790L;
-
-		/**
-		 * The state of the underlying algorithm.
-		 */
-		private final Serializable algorithmState;
-		
-		/**
-		 * The {@code observations} from the {@code InstrumentedAlgorithm} instance.
-		 */
-		private final Observations observations;
-
-		/**
-		 * Constructs a proxy for storing the state of an {@code InstrumentedAlgorithm} instance.
-		 * 
-		 * @param algorithmState the state of the underlying algorithm
-		 * @param observations the {@code observations} from the {@code InstrumentedAlgorithm} instance
-		 */
-		public InstrumentedAlgorithmState(Serializable algorithmState, Observations observations) {
-			super();
-			this.algorithmState = algorithmState;
-			this.observations = observations;
-		}
-
-		/**
-		 * Returns the underlying algorithm state.
-		 * 
-		 * @return the underlying algorithm state
-		 */
-		public Serializable getAlgorithmState() {
-			return algorithmState;
-		}
-
-		/**
-		 * Returns the {@code observations} from the {@code InstrumentedAlgorithm} instance.
-		 * 
-		 * @return the {@code observations} from the {@code InstrumentedAlgorithm} instance
-		 */
-		public Observations getObservations() {
-			return observations;
-		}
-		
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeObject(observations);
 	}
 
 	@Override
-	public Serializable getState() throws NotSerializableException {
-		return new InstrumentedAlgorithmState(super.getState(), observations);
-	}
-
-	@Override
-	public void setState(Object objState) throws NotSerializableException {
-		InstrumentedAlgorithmState state = (InstrumentedAlgorithmState)objState;
-		
-		super.setState(state.getAlgorithmState());
-		
-		//copy the stored observations content
-		Observations storedObservations = state.getObservations();
-		
-		for (Observation observation : storedObservations) {
-			observations.add(observation);
-		}
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		observations = (Observations)stream.readObject();
 	}
 	
 }

--- a/src/org/moeaframework/core/AdaptiveGridArchive.java
+++ b/src/org/moeaframework/core/AdaptiveGridArchive.java
@@ -17,6 +17,9 @@
  */
 package org.moeaframework.core;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -168,7 +171,7 @@ public class AdaptiveGridArchive extends NondominatedPopulation {
 		while (iterator.hasNext()) {
 			Solution oldSolution = iterator.next();
 			int flag = comparator.compare(solution, oldSolution);
-
+			
 			if (flag < 0) {
 				// candidate dominates a member of the archive
 				iterator.remove();
@@ -354,6 +357,22 @@ public class AdaptiveGridArchive extends NondominatedPopulation {
 	 */
 	public int getDensity(int index) {
 		return density[index];
+	}
+	
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeObject(minimum);
+		stream.writeObject(maximum);
+		stream.writeObject(density);
+	}
+
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		minimum = (double[])stream.readObject();
+		maximum = (double[])stream.readObject();
+		density = (int[])stream.readObject();
 	}
 
 }

--- a/src/org/moeaframework/core/Algorithm.java
+++ b/src/org/moeaframework/core/Algorithm.java
@@ -17,10 +17,6 @@
  */
 package org.moeaframework.core;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
-
-import org.moeaframework.algorithm.AlgorithmException;
 import org.moeaframework.core.termination.MaxFunctionEvaluations;
 
 /**
@@ -30,7 +26,7 @@ import org.moeaframework.core.termination.MaxFunctionEvaluations;
  * may completely solve a problem in one step or may require hundreds of
  * thousands of steps.
  */
-public interface Algorithm {
+public interface Algorithm extends Stateful {
 
 	/**
 	 * Returns the problem being solved by this algorithm.
@@ -117,28 +113,4 @@ public interface Algorithm {
 	 */
 	public void terminate();
 	
-	/**
-	 * Returns a {@code Serializable} object representing the internal state of
-	 * this algorithm.
-	 * 
-	 * @return a {@code Serializable} object representing the internal state of
-	 *         this algorithm
-	 * @throws NotSerializableException if this algorithm does not support
-	 *         serialization
-	 * @throws AlgorithmException if this algorithm has not yet been
-	 *         initialized
-	 */
-	public Serializable getState() throws NotSerializableException;
-
-	/**
-	 * Sets the internal state of of this algorithm.
-	 * 
-	 * @param state the internal state of this algorithm
-	 * @throws NotSerializableException if this algorithm does not support
-	 *         serialization
-	 * @throws AlgorithmException if this algorithm has already been
-	 *         initialized
-	 */
-	public void setState(Object state) throws NotSerializableException;
-
 }

--- a/src/org/moeaframework/core/EpsilonBoxDominanceArchive.java
+++ b/src/org/moeaframework/core/EpsilonBoxDominanceArchive.java
@@ -17,6 +17,9 @@
  */
 package org.moeaframework.core;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Iterator;
 
 import org.moeaframework.core.comparator.EpsilonBoxDominanceComparator;
@@ -195,6 +198,20 @@ public class EpsilonBoxDominanceArchive extends NondominatedPopulation {
 	 */
 	public int getNumberOfDominatingImprovements() {
 		return numberOfDominatingImprovements;
+	}
+	
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeInt(numberOfImprovements);
+		stream.writeInt(numberOfDominatingImprovements);
+	}
+
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		numberOfImprovements = stream.readInt();
+		numberOfDominatingImprovements = stream.readInt();
 	}
 
 }

--- a/src/org/moeaframework/core/NondominatedSortingPopulation.java
+++ b/src/org/moeaframework/core/NondominatedSortingPopulation.java
@@ -21,6 +21,7 @@ import static org.moeaframework.core.NondominatedSorting.RANK_ATTRIBUTE;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Comparator;
 import java.util.Iterator;
 
@@ -237,9 +238,15 @@ public class NondominatedSortingPopulation extends Population {
 	}
 	
 	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		super.saveState(stream);
+		stream.writeBoolean(modified);
+	}
+	
+	@Override
 	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 		super.loadState(stream);
-		update();
+		modified = stream.readBoolean();
 	}
 
 }

--- a/src/org/moeaframework/core/NondominatedSortingPopulation.java
+++ b/src/org/moeaframework/core/NondominatedSortingPopulation.java
@@ -19,6 +19,8 @@ package org.moeaframework.core;
 
 import static org.moeaframework.core.NondominatedSorting.RANK_ATTRIBUTE;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Comparator;
 import java.util.Iterator;
 
@@ -232,6 +234,12 @@ public class NondominatedSortingPopulation extends Population {
 	public void update() {
 		modified = false;
 		nondominatedSorting.evaluate(this);
+	}
+	
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		super.loadState(stream);
+		update();
 	}
 
 }

--- a/src/org/moeaframework/core/Population.java
+++ b/src/org/moeaframework/core/Population.java
@@ -17,6 +17,9 @@
  */
 package org.moeaframework.core;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,7 +36,7 @@ import org.moeaframework.util.format.TabularData;
 /**
  * A collection of solutions and common methods for manipulating the collection.
  */
-public class Population implements Iterable<Solution>, Formattable<Solution> {
+public class Population implements Iterable<Solution>, Formattable<Solution>, Stateful {
 
 	/**
 	 * The internal data storage for solutions.
@@ -455,6 +458,7 @@ public class Population implements Iterable<Solution>, Formattable<Solution> {
 				currentIndex = -1;
 				expectedModCount++;
 			} catch (IndexOutOfBoundsException e) {
+				System.out.println(e + " " + size() + " " + currentIndex + " " + nextIndex + " " + expectedModCount);
 				throw new ConcurrentModificationException();
 			}
 		}
@@ -471,6 +475,18 @@ public class Population implements Iterable<Solution>, Formattable<Solution> {
 				throw new ConcurrentModificationException();
 			}
 		}
+	}
+
+	@Override
+	public void saveState(ObjectOutputStream stream) throws IOException {
+		stream.writeObject(data);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		data.clear();
+		data.addAll((List<Solution>)stream.readObject());
 	}
 
 }

--- a/src/org/moeaframework/core/Stateful.java
+++ b/src/org/moeaframework/core/Stateful.java
@@ -1,0 +1,63 @@
+package org.moeaframework.core;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * Interface for objects that can save and load their state.
+ */
+public interface Stateful {
+	
+	/**
+	 * Writes the state of this object to the stream.
+	 * 
+	 * @param stream the stream
+	 * @throws IOException if an I/O error occurred
+	 */
+	public default void saveState(ObjectOutputStream stream) throws IOException {
+		stream.writeObject(getState());
+	}
+
+	/**
+	 * Loads the state of this object from the stream.
+	 * 
+	 * @param stream the stream
+	 * @throws IOException if an I/O error occurred
+	 * @throws ClassNotFoundException if the stream referenced a class that is not defined
+	 */
+	public default void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+		setState(stream.readObject());
+	}
+	
+	/**
+	 * Returns a {@code Serializable} object representing the internal state of
+	 * this algorithm.
+	 * 
+	 * @return a {@code Serializable} object representing the internal state of this algorithm
+	 * @throws NotSerializableException if this algorithm does not support serialization
+	 * @throws AlgorithmException if this algorithm has not yet been initialized
+	 * @deprecated use {@link #loadState(ObjectInputStream)} instead
+	 */
+	@Deprecated
+	public default Serializable getState() throws NotSerializableException {
+		throw new NotSerializableException(getClass().getSimpleName());
+	}
+
+	/**
+	 * Sets the internal state of of this algorithm.
+	 * 
+	 * @param state the internal state of this algorithm
+	 * @throws NotSerializableException if this algorithm does not support serialization
+	 * @throws AlgorithmException if this algorithm has already been initialized
+	 * @deprecated use {@link #saveState(ObjectOutputStream) instead
+	 */
+	@Deprecated
+	public default void setState(Object state) throws NotSerializableException {
+		throw new NotSerializableException(getClass().getSimpleName());
+	}
+
+
+}

--- a/test/org/moeaframework/InstrumenterTest.java
+++ b/test/org/moeaframework/InstrumenterTest.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
@@ -127,12 +128,12 @@ public class InstrumenterTest {
 		}
 
 		@Override
-		public Serializable getState() throws NotSerializableException {
+		public void saveState(ObjectOutputStream stream) throws IOException {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void setState(Object state) throws NotSerializableException {
+		public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 			throw new UnsupportedOperationException();
 		}
 		

--- a/test/org/moeaframework/algorithm/AdaptiveTimeContinuationTest.java
+++ b/test/org/moeaframework/algorithm/AdaptiveTimeContinuationTest.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -103,12 +104,12 @@ public class AdaptiveTimeContinuationTest {
 		}
 
 		@Override
-		public Serializable getState() throws NotSerializableException {
+		public void saveState(ObjectOutputStream stream) throws IOException {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void setState(Object state) throws NotSerializableException {
+		public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 			throw new UnsupportedOperationException();
 		}
 		

--- a/test/org/moeaframework/algorithm/DefaultAlgorithmsResumeTest.java
+++ b/test/org/moeaframework/algorithm/DefaultAlgorithmsResumeTest.java
@@ -108,7 +108,6 @@ public class DefaultAlgorithmsResumeTest {
 	}
 
 	@Test
-	@Ignore("occasionally fails due to the AdaptiveGridArchive not being serialized properly")
 	public void testPESA2() throws IOException {
 		test("PESA2");
 	}

--- a/test/org/moeaframework/algorithm/DefaultAlgorithmsResumeTest.java
+++ b/test/org/moeaframework/algorithm/DefaultAlgorithmsResumeTest.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.moeaframework.TestUtils;
 import org.moeaframework.analysis.collector.IndicatorCollector;
@@ -31,12 +30,10 @@ import org.moeaframework.analysis.collector.Observations;
 import org.moeaframework.analysis.sensitivity.EpsilonHelper;
 import org.moeaframework.core.Algorithm;
 import org.moeaframework.core.EpsilonBoxDominanceArchive;
-import org.moeaframework.core.EvolutionaryAlgorithm;
 import org.moeaframework.core.Initialization;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.NondominatedSortingPopulation;
 import org.moeaframework.core.PRNG;
-import org.moeaframework.core.Population;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Variation;
 import org.moeaframework.core.comparator.ChainedComparator;
@@ -158,13 +155,11 @@ public class DefaultAlgorithmsResumeTest {
 	}
 	
 	@Test
-	@Ignore("currently resume capability is not supported")
 	public void testRSO() throws IOException {
 		test("RSO");
 	}
 	
 	@Test
-	@Ignore("currently resume capability is not supported")
 	public void testMSOPS() throws IOException {
 		test("MSOPS");
 	}
@@ -196,19 +191,6 @@ public class DefaultAlgorithmsResumeTest {
 				algorithmName, new TypedProperties(), problem);
 		
 		for (int i = 0; i < N && !algorithm.isTerminated(); i++) {
-			// Due to how NondominatedSortingPopulation automatically
-			// recalculates ranks and crowding distances, the checkpoint
-			// version slightly differs due to an extra update.  This hack
-			// allows this test to align with the checkpoint version.
-			if (algorithm instanceof EvolutionaryAlgorithm) {
-				Population population = 
-						((EvolutionaryAlgorithm)algorithm).getPopulation();
-							
-				if (population instanceof NondominatedSortingPopulation) {
-					((NondominatedSortingPopulation)population).update();
-				}
-			}
-			
 			algorithm.step();
 		}
 		
@@ -250,19 +232,6 @@ public class DefaultAlgorithmsResumeTest {
 				new Hypervolume(problem, referenceSet)).attach(algorithm));
 		
 		for (int i = 0; i < N; i++) {
-			// Due to how NondominatedSortingPopulation automatically
-			// recalculates ranks and crowding distances, the checkpoint
-			// version slightly differs due to an extra update.  This hack
-			// allows this test to align with the checkpoint version.
-			if (algorithm instanceof EvolutionaryAlgorithm) {
-				Population population = 
-						((EvolutionaryAlgorithm)algorithm).getPopulation();
-							
-				if (population instanceof NondominatedSortingPopulation) {
-					((NondominatedSortingPopulation)population).update();
-				}
-			}
-			
 			instrumentedAlgorithm.step();
 		}
 

--- a/test/org/moeaframework/algorithm/EpsilonProgressContinuationTest.java
+++ b/test/org/moeaframework/algorithm/EpsilonProgressContinuationTest.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -98,12 +99,12 @@ public class EpsilonProgressContinuationTest {
 		}
 
 		@Override
-		public Serializable getState() throws NotSerializableException {
+		public void saveState(ObjectOutputStream stream) throws IOException {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void setState(Object state) throws NotSerializableException {
+		public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 			throw new UnsupportedOperationException();
 		}
 		

--- a/test/org/moeaframework/algorithm/PeriodicActionTest.java
+++ b/test/org/moeaframework/algorithm/PeriodicActionTest.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.algorithm;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -73,12 +74,12 @@ public class PeriodicActionTest {
 		}
 
 		@Override
-		public Serializable getState() throws NotSerializableException {
+		public void saveState(ObjectOutputStream stream) throws IOException {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void setState(Object state) throws NotSerializableException {
+		public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 			throw new UnsupportedOperationException();
 		}
 		

--- a/test/org/moeaframework/core/spi/AlgorithmFactoryTestWrapper.java
+++ b/test/org/moeaframework/core/spi/AlgorithmFactoryTestWrapper.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.core.spi;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.moeaframework.core.Algorithm;
 import org.moeaframework.core.NondominatedPopulation;
@@ -82,13 +83,13 @@ public class AlgorithmFactoryTestWrapper extends AlgorithmFactory {
 			}
 
 			@Override
-			public Serializable getState() throws NotSerializableException {
-				return algorithm.getState();
+			public void saveState(ObjectOutputStream stream) throws IOException {
+				algorithm.saveState(stream);
 			}
 
 			@Override
-			public void setState(Object state) throws NotSerializableException {
-				algorithm.setState(state);
+			public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+				algorithm.loadState(stream);
 			}
 			
 		};

--- a/test/org/moeaframework/core/termination/MockAlgorithm.java
+++ b/test/org/moeaframework/core/termination/MockAlgorithm.java
@@ -17,8 +17,9 @@
  */
 package org.moeaframework.core.termination;
 
-import java.io.NotSerializableException;
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.moeaframework.core.Algorithm;
 import org.moeaframework.core.NondominatedPopulation;
@@ -69,12 +70,12 @@ public class MockAlgorithm implements Algorithm {
 	}
 
 	@Override
-	public Serializable getState() throws NotSerializableException {
+	public void saveState(ObjectOutputStream stream) throws IOException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void setState(Object state) throws NotSerializableException {
+	public void loadState(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 		throw new UnsupportedOperationException();
 	}
 


### PR DESCRIPTION
Improvements to how state and resumability is handled, namely:

1. Replaces the `getState` and `setState` methods that required creating a Serializable state class with `saveState` and `loadState` methods that write directly to the stream.  This has a few advantages:
   * Removes a lot of boilerplate code creating the Serializable classes (nearly 900 lines of code removed)
   * No longer need to clone objects, as the state is written immediately to the file
   * Allows each class in the type hierarchy to define its state
3. These methods are moved to the `Stateful` interface, allowing any class to implement these methods
4. Update `Checkpoints` to save the state file to a temporary file first, to avoid corrupting any existing file if an error occurs during the write.
5. Adds resuability support to MSOPS and RSO

