### PR TITLE
Improve handling on truncated properties

### DIFF
--- a/moeaframework.properties
+++ b/moeaframework.properties
@@ -30,6 +30,12 @@
 ## testing both options to see which performs well.
 #org.moeaframework.core.fast_nondominated_sorting = false
 
+## Suppress all warnings when a parameter is being implicitly converted from a
+## real-value to an integer and the decimal places are truncated.  For example,
+## population size is expected to be an integer, but if given as a real-value
+## it will be converted to an integer (e.g., 100.2 -> 100).
+#org.moeaframework.core.suppress_truncation_warning = true
+
 ## Genetic programming functions are by default protected against returning
 ## NaN or other invalid numbers.  Unless protected against, these invalid
 ## values propagate throughout the expression and corrupt the results.  This

--- a/moeaframework.properties
+++ b/moeaframework.properties
@@ -30,10 +30,11 @@
 ## testing both options to see which performs well.
 #org.moeaframework.core.fast_nondominated_sorting = false
 
-## Suppress all warnings when a parameter is being implicitly converted from a
-## real-value to an integer and the decimal places are truncated.  For example,
-## population size is expected to be an integer, but if given as a real-value
-## it will be converted to an integer (e.g., 100.2 -> 100).
+## When a property is given as a real-value but needs to be converted to an integer,
+## we implicitly allow truncating the decimal places.  This allows, for example,
+## automatically converting parameter inputs generated for sensitivity analysis.
+## When this conversion alters the value, a warning is displayed.  Consider setting
+## this to true to suppress the warning message.
 #org.moeaframework.core.suppress_truncation_warning = true
 
 ## Genetic programming functions are by default protected against returning

--- a/src/org/moeaframework/Executor.java
+++ b/src/org/moeaframework/Executor.java
@@ -667,8 +667,8 @@ public class Executor extends ProblemBuilder {
 	 * @return the termination condition
 	 */
 	protected TerminationCondition createTerminationCondition() {
-		int maxEvaluations = (int)properties.getDouble("maxEvaluations", -1);
-		long maxTime = (long)properties.getDouble("maxTime", -1);
+		int maxEvaluations = properties.getTruncatedInt("maxEvaluations", -1);
+		long maxTime = (long)properties.getDouble("maxTime", -1); // TODO
 		
 		// create a list of the termination conditions
 		List<TerminationCondition> conditions = new ArrayList<TerminationCondition>();

--- a/src/org/moeaframework/Executor.java
+++ b/src/org/moeaframework/Executor.java
@@ -668,7 +668,7 @@ public class Executor extends ProblemBuilder {
 	 */
 	protected TerminationCondition createTerminationCondition() {
 		int maxEvaluations = properties.getTruncatedInt("maxEvaluations", -1);
-		long maxTime = (long)properties.getDouble("maxTime", -1); // TODO
+		long maxTime = properties.getTruncatedLong("maxTime", -1);
 		
 		// create a list of the termination conditions
 		List<TerminationCondition> conditions = new ArrayList<TerminationCondition>();

--- a/src/org/moeaframework/algorithm/DefaultAlgorithms.java
+++ b/src/org/moeaframework/algorithm/DefaultAlgorithms.java
@@ -138,7 +138,7 @@ public class DefaultAlgorithms extends RegisteredAlgorithmProvider {
 
 	private Algorithm newRSO(TypedProperties properties, Problem problem) {
 		String algorithmName = properties.getString("algorithm", "GA");
-		int instances = (int)properties.getDouble("instances", 100);
+		int instances = properties.getTruncatedInt("instances", 100);
 		
 		if (!properties.contains("method")) {
 			properties.setString("method", "min-max");

--- a/src/org/moeaframework/analysis/sensitivity/DetailedEvaluator.java
+++ b/src/org/moeaframework/analysis/sensitivity/DetailedEvaluator.java
@@ -237,10 +237,10 @@ public class DetailedEvaluator extends CommandLineUtility {
 	@SuppressWarnings("unchecked")
 	protected void process(String algorithmName, TypedProperties properties, Problem problem, int frequency)
 			throws IOException {
-		int maxEvaluations = (int)properties.getDouble("maxEvaluations", -1);
+		int maxEvaluations = properties.getTruncatedInt("maxEvaluations");
 		
 		if (maxEvaluations < 0) {
-			throw new FrameworkException("maxEvaluations not defined or invalid");
+			throw new FrameworkException("maxEvaluations must be a non-negative number");
 		}
 		
 		Instrumenter instrumenter = new Instrumenter()

--- a/src/org/moeaframework/analysis/sensitivity/Evaluator.java
+++ b/src/org/moeaframework/analysis/sensitivity/Evaluator.java
@@ -266,10 +266,10 @@ public class Evaluator extends CommandLineUtility {
 				algorithmName, properties, timingProblem);
 
 		// find the maximum NFE to run
-		int maxEvaluations = (int)properties.getDouble("maxEvaluations", -1);
+		int maxEvaluations = properties.getTruncatedInt("maxEvaluations");
 		
 		if (maxEvaluations < 0) {
-			throw new FrameworkException("maxEvaluations not defined or invalid");
+			throw new FrameworkException("maxEvaluations must be a non-negative number");
 		}
 
 		// run the algorithm

--- a/src/org/moeaframework/core/Settings.java
+++ b/src/org/moeaframework/core/Settings.java
@@ -95,6 +95,11 @@ public class Settings {
 	static final String KEY_FAST_NONDOMINATED_SORTING = createKey(KEY_PREFIX, "core", "fast_nondominated_sorting");
 	
 	/**
+	 * The property key to indicate that truncation warnings should be suppressed.
+	 */
+	public static final String KEY_SUPPRESS_TRUNCATION_WARNING = createKey(KEY_PREFIX, "core", "suppress_truncation_warning");
+	
+	/**
 	 * The property key for the continuity correction flag.
 	 */
 	static final String KEY_CONTINUITY_CORRECTION = createKey(KEY_PREFIX, "util", "statistics", "continuity_correction");
@@ -296,6 +301,17 @@ public class Settings {
 	 */
 	public static boolean useFastNondominatedSorting() {
 		return PROPERTIES.getBoolean(KEY_FAST_NONDOMINATED_SORTING, false);
+	}
+	
+	/**
+	 * Returns {@code true} if truncation warnings, when implicitly converting a
+	 * real-valued property to an integer and truncating the decimal value, should be
+	 * suppressed.
+	 * 
+	 * @return {@code true} if truncation warnings are suppressed; {@code false} otherwise
+	 */
+	public static boolean isSuppressTruncationWarning() {
+		return PROPERTIES.getBoolean(KEY_SUPPRESS_TRUNCATION_WARNING, false);
 	}
 	
 	/**

--- a/src/org/moeaframework/core/configuration/ConfigurationUtils.java
+++ b/src/org/moeaframework/core/configuration/ConfigurationUtils.java
@@ -184,14 +184,7 @@ public class ConfigurationUtils {
 		} else if (TypeUtils.isAssignable(long.class, parameterType)) {
 			value = properties.getLong(propertyName);
 		} else if (TypeUtils.isAssignable(int.class, parameterType)) {
-			try {
-				value = properties.getInt(propertyName);
-			} catch (NumberFormatException e) {
-				value = (int)properties.getDouble(propertyName);
-				
-				System.err.println(propertyName + " given as floating-point but expected an int, converting " +
-						properties.getString(propertyName) + " to " + value);
-			}
+			value = properties.getTruncatedInt(propertyName);
 		} else if (TypeUtils.isAssignable(short.class, parameterType)) {
 			value = properties.getShort(propertyName);
 		} else if (TypeUtils.isAssignable(byte.class, parameterType)) {

--- a/src/org/moeaframework/util/TypedProperties.java
+++ b/src/org/moeaframework/util/TypedProperties.java
@@ -334,7 +334,7 @@ public class TypedProperties implements Displayable {
 	//
 	//   1. If no truncation is required, the number is parsed as-is.
 	//   2. If the truncation alters the value more than the defined machine precision, Settings.EPS,
-	//      than a warning is displayed.
+	//      then a warning is displayed.
 	//   3. If the truncation would alter the value more than 1.0, an exception is thrown. This includes
 	//      trying to parse a value that exceeds the maximum or minimum value that fits within a type.
 	

--- a/src/org/moeaframework/util/weights/NormalBoundaryDivisions.java
+++ b/src/org/moeaframework/util/weights/NormalBoundaryDivisions.java
@@ -148,8 +148,8 @@ public class NormalBoundaryDivisions {
 	public static NormalBoundaryDivisions tryFromProperties(TypedProperties properties) {
 		if (properties.contains("divisionsOuter") && properties.contains("divisionsInner")) {
 			return new NormalBoundaryDivisions(
-					properties.getInt("divisionsOuter"),
-					properties.getInt("divisionsInner"));
+					properties.getTruncatedInt("divisionsOuter"),
+					properties.getTruncatedInt("divisionsInner"));
 		} 
 		
 		if (properties.contains("divisionsOuter") || properties.contains("divisionsInner")) {
@@ -157,7 +157,7 @@ public class NormalBoundaryDivisions {
 		}
 		
 		if (properties.contains("divisions")) {
-			return new NormalBoundaryDivisions(properties.getInt("divisions"));
+			return new NormalBoundaryDivisions(properties.getTruncatedInt("divisions"));
 		}
 		
 		return null;

--- a/test/org/moeaframework/util/TypedPropertiesTest.java
+++ b/test/org/moeaframework/util/TypedPropertiesTest.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.Settings;
 
 /**
@@ -280,6 +281,42 @@ public class TypedPropertiesTest {
 		Assert.assertFalse(properties.getUnaccessedProperties().isEmpty());
 		Assert.assertTrue(properties.getUnaccessedProperties().contains("Baz"));
 		Assert.assertTrue(properties.getUnaccessedProperties().contains("BAZ"));
+	}
+	
+	@Test
+	public void testTruncation() {
+		int intValue = Integer.MAX_VALUE;
+		long longValue = Long.MAX_VALUE;
+		
+		TypedProperties properties = new TypedProperties();
+		properties.setDouble("double", 2.71);
+		properties.setInt("int", intValue);
+		properties.setLong("long", longValue);
+		properties.setDouble("max_double", Double.MAX_VALUE);
+		
+		Assert.assertEquals(intValue, properties.getInt("int"));
+		Assert.assertEquals(intValue, properties.getTruncatedInt("int"));
+		
+		Assert.assertEquals(intValue, properties.getInt("missing", intValue));
+		Assert.assertEquals(intValue, properties.getTruncatedInt("missing", intValue));
+		
+		Assert.assertThrows(NumberFormatException.class, () -> properties.getInt("double"));
+		Assert.assertEquals(2, properties.getTruncatedInt("double"));
+		
+		Assert.assertEquals(longValue, properties.getLong("long"));
+		Assert.assertEquals(longValue, properties.getTruncatedLong("long"));
+		
+		Assert.assertEquals(longValue, properties.getLong("missing", longValue));
+		Assert.assertEquals(longValue, properties.getTruncatedLong("missing", longValue));
+		
+		Assert.assertThrows(NumberFormatException.class, () -> properties.getLong("double"));
+		Assert.assertEquals(2, properties.getTruncatedLong("double"));
+		
+		// if the truncation would change the value by more than 1, throw instead of warn
+		Assert.assertThrows(NumberFormatException.class, () -> properties.getInt("long"));
+		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedInt("long"));
+		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedInt("max_double"));
+		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedLong("max_double"));
 	}
 	
 	private enum TestEnum {

--- a/test/org/moeaframework/util/TypedPropertiesTest.java
+++ b/test/org/moeaframework/util/TypedPropertiesTest.java
@@ -293,6 +293,7 @@ public class TypedPropertiesTest {
 		properties.setInt("int", intValue);
 		properties.setLong("long", longValue);
 		properties.setDouble("max_double", Double.MAX_VALUE);
+		properties.setDouble("min_double", -Double.MAX_VALUE);
 		
 		Assert.assertEquals(intValue, properties.getInt("int"));
 		Assert.assertEquals(intValue, properties.getTruncatedInt("int"));
@@ -317,6 +318,8 @@ public class TypedPropertiesTest {
 		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedInt("long"));
 		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedInt("max_double"));
 		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedLong("max_double"));
+		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedInt("min_double"));
+		Assert.assertThrows(FrameworkException.class, () -> properties.getTruncatedLong("min_double"));
 	}
 	
 	private enum TestEnum {


### PR DESCRIPTION
Fixes #384 

Expands support for truncating properties from real-values to integers or longs.  The following rules are now enforced:

1. If the difference is very small, below the configured machine precision `Settings.EPS`, the conversion is allowed.  For example, `5.0 -> 5` or `5.00000000000001 -> 5` are permitted.
2. If the difference is less than `1.0` (i.e., the integer portion is unchanged), the conversion is allowed but a warning is displayed.  This is to prevent unexpected changes in behavior.  For users performing sensitivity analysis or want to hide this warning, consider setting `org.moeaframework.core.suppress_truncation_warning = true`.
3. If the difference is greater than or equal to `1.0`, the conversion is **not** allowed and an exception is thrown.  This primarily happens when trying to fit a large `double` or `long` into an `int`, and due to how Java handles this casting would result in a completely different number.