### PR TITLE
Standardize constraint values to match historical behavior

### DIFF
--- a/examples/Example6.java
+++ b/examples/Example6.java
@@ -16,6 +16,7 @@
  * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
  */
 import org.moeaframework.algorithm.NSGAII;
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
@@ -52,9 +53,10 @@ public class Example6 {
 			solution.setObjective(0, f1);
 			solution.setObjective(1, f2);
 			
-			// set the constraint values - we treat any non-zero value as a constraint violation!
-			solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-			solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
+			// set the constraint values - indicate violations with any non-zero value, or use
+			// the appropriate method from the Constraint class.
+			solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+			solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
 		}
 
 		/**

--- a/src/org/moeaframework/core/Constraint.java
+++ b/src/org/moeaframework/core/Constraint.java
@@ -32,9 +32,10 @@ package org.moeaframework.core;
  *       the feasible solution.  This helps optimization algorithms distinguish solutions with
  *       more or less severe violations.
  * </ol>
+ * <p>
  */
 public class Constraint {
-	
+
 	/**
 	 * Constant used to indicate a constraint is satisfied.
 	 */
@@ -137,7 +138,7 @@ public class Constraint {
 	 */
 	public static double greaterThanOrEqual(double x, double y, double epsilon) {
 		double diff = Math.abs(x - y);
-		return x >= y || diff <= epsilon ? 0.0 : diff;
+		return x >= y || diff <= epsilon ? 0.0 : -diff;
 	}
 	
 	/**
@@ -185,7 +186,7 @@ public class Constraint {
 	 */
 	public static double greaterThan(double x, double y, double epsilon) {
 		double diff = Math.abs(x - y);
-		return x > y && diff > epsilon ? 0.0 : Math.nextUp(diff);
+		return x > y && diff > epsilon ? 0.0 : Math.nextDown(-diff);
 	}
 	
 	/**
@@ -212,7 +213,7 @@ public class Constraint {
 	public static double between(double lower, double value, double upper, double epsilon) {
 		if (value < lower) {
 			double diff = Math.abs(lower - value);
-			return diff <= epsilon ? 0.0 : diff;
+			return diff <= epsilon ? 0.0 : -diff;
 		}
 		
 		if (value > upper) {
@@ -245,17 +246,22 @@ public class Constraint {
 	 * @return the constraint value
 	 */
 	public static double outside(double lower, double value, double upper, double epsilon) {
-		if (value < lower) {
-			double diff = Math.abs(lower - value);
-			return diff > epsilon ? 0.0 : Math.nextUp(diff);
+		double diffLower = Math.abs(lower - value);
+		double diffUpper = Math.abs(upper - value);
+		
+		if (value < lower) {	
+			return diffLower > epsilon ? 0.0 : Math.nextUp(diffLower);
 		}
 		
 		if (value > upper) {
-			double diff = Math.abs(upper - value);
-			return diff > epsilon ? 0.0 : Math.nextUp(diff);
+			return diffUpper > epsilon ? 0.0 : Math.nextDown(-diffUpper);
 		}
 		
-		return Math.max(Math.abs(lower - value), Math.abs(upper - value));
+		if (diffLower < diffUpper) {
+			return diffLower;
+		} else {
+			return -diffUpper;
+		}
 	}
 
 }

--- a/src/org/moeaframework/problem/CDTLZ/C1_DTLZ1.java
+++ b/src/org/moeaframework/problem/CDTLZ/C1_DTLZ1.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CDTLZ;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.DTLZ.DTLZ1;
@@ -63,7 +64,7 @@ public class C1_DTLZ1 extends DTLZ1 {
 			c -= solution.getObjective(i) / 0.5;
 		}
 		
-		solution.setConstraint(0, c >= 0.0 ? 0.0 : c);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CDTLZ/C1_DTLZ3.java
+++ b/src/org/moeaframework/problem/CDTLZ/C1_DTLZ3.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CDTLZ;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.DTLZ.DTLZ3;
@@ -65,7 +66,7 @@ public class C1_DTLZ3 extends DTLZ3 {
 		
 		double c = (sumsq - 16) * (sumsq - Math.pow(getR(), 2.0));
 		
-		solution.setConstraint(0, c >= 0.0 ? 0.0 : c);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c, 0.0));
 	}
 	
 	private double getR() {

--- a/src/org/moeaframework/problem/CDTLZ/C2_DTLZ2.java
+++ b/src/org/moeaframework/problem/CDTLZ/C2_DTLZ2.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CDTLZ;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.DTLZ.DTLZ2;
@@ -76,7 +77,7 @@ public class C2_DTLZ2 extends DTLZ2 {
 		}
 		
 		double c = Math.min(v1, v2 - Math.pow(r, 2.0));
-		solution.setConstraint(0, c <= 0.0 ? 0.0 : c);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CDTLZ/C3_DTLZ1.java
+++ b/src/org/moeaframework/problem/CDTLZ/C3_DTLZ1.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CDTLZ;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.DTLZ.DTLZ1;
@@ -66,7 +67,7 @@ public class C3_DTLZ1 extends DTLZ1 {
 				}
 			}
 			
-			solution.setConstraint(j, c >= 0.0 ? 0.0 : c);
+			solution.setConstraint(j, Constraint.greaterThanOrEqual(c, 0.0));
 		}
 	}
 

--- a/src/org/moeaframework/problem/CDTLZ/C3_DTLZ4.java
+++ b/src/org/moeaframework/problem/CDTLZ/C3_DTLZ4.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CDTLZ;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.DTLZ.DTLZ4;
@@ -66,7 +67,7 @@ public class C3_DTLZ4 extends DTLZ4 {
 				}
 			}
 			
-			solution.setConstraint(j, c >= 0.0 ? 0.0 : c);
+			solution.setConstraint(j, Constraint.greaterThanOrEqual(c, 0.0));
 		}
 	}
 

--- a/src/org/moeaframework/problem/CDTLZ/ConvexC2_DTLZ2.java
+++ b/src/org/moeaframework/problem/CDTLZ/ConvexC2_DTLZ2.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CDTLZ;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 
@@ -82,7 +83,7 @@ public class ConvexC2_DTLZ2 extends ConvexDTLZ2 {
 		
 		c -= Math.pow(getR(), 2.0);
 		
-		solution.setConstraint(0, c >= 0 ? 0.0 : c);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c, 0.0));
 	}
 	
 	private double getR() {

--- a/src/org/moeaframework/problem/CEC2009/CF1.java
+++ b/src/org/moeaframework/problem/CEC2009/CF1.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,7 +55,7 @@ public class CF1 extends AbstractProblem {
 		CEC2009.CF1(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF10.java
+++ b/src/org/moeaframework/problem/CEC2009/CF10.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,7 +55,7 @@ public class CF10 extends AbstractProblem {
 		CEC2009.CF10(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF2.java
+++ b/src/org/moeaframework/problem/CEC2009/CF2.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,7 +55,7 @@ public class CF2 extends AbstractProblem {
 		CEC2009.CF2(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF3.java
+++ b/src/org/moeaframework/problem/CEC2009/CF3.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,7 +55,7 @@ public class CF3 extends AbstractProblem {
 		CEC2009.CF3(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF5.java
+++ b/src/org/moeaframework/problem/CEC2009/CF5.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,7 +55,7 @@ public class CF5 extends AbstractProblem {
 		CEC2009.CF5(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF6.java
+++ b/src/org/moeaframework/problem/CEC2009/CF6.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,8 +55,8 @@ public class CF6 extends AbstractProblem {
 		CEC2009.CF6(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
-		solution.setConstraint(1, c[1] >= 0.0 ? 0.0 : c[1]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
+		solution.setConstraint(1, Constraint.greaterThanOrEqual(c[1], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF7.java
+++ b/src/org/moeaframework/problem/CEC2009/CF7.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,8 +55,8 @@ public class CF7 extends AbstractProblem {
 		CEC2009.CF7(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
-		solution.setConstraint(1, c[1] >= 0.0 ? 0.0 : c[1]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
+		solution.setConstraint(1, Constraint.greaterThanOrEqual(c[1], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF8.java
+++ b/src/org/moeaframework/problem/CEC2009/CF8.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,7 +55,7 @@ public class CF8 extends AbstractProblem {
 		CEC2009.CF8(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/CEC2009/CF9.java
+++ b/src/org/moeaframework/problem/CEC2009/CF9.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.CEC2009;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.core.variable.RealVariable;
@@ -54,7 +55,7 @@ public class CF9 extends AbstractProblem {
 		CEC2009.CF9(x, f, c, numberOfVariables);
 
 		solution.setObjectives(f);
-		solution.setConstraint(0, c[0] >= 0.0 ? 0.0 : c[0]);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c[0], 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Belegundu.java
+++ b/src/org/moeaframework/problem/misc/Belegundu.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -62,8 +63,8 @@ public class Belegundu extends AbstractProblem {
 		
 		solution.setObjective(0, f1);
 		solution.setObjective(1, f2);
-		solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Binh2.java
+++ b/src/org/moeaframework/problem/misc/Binh2.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -62,8 +63,8 @@ public class Binh2 extends AbstractProblem {
 		
 		solution.setObjective(0, f1);
 		solution.setObjective(1, f2);
-		solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Binh4.java
+++ b/src/org/moeaframework/problem/misc/Binh4.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
 import org.moeaframework.problem.AbstractProblem;
@@ -65,8 +66,8 @@ public class Binh4 extends AbstractProblem implements AnalyticalProblem {
 		solution.setObjective(0, f1);
 		solution.setObjective(1, f2);
 		solution.setObjective(2, f3);
-		solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Jimenez.java
+++ b/src/org/moeaframework/problem/misc/Jimenez.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
@@ -68,10 +69,10 @@ public class Jimenez extends AbstractProblem implements AnalyticalProblem {
 		
 		solution.setObjective(0, -f1);
 		solution.setObjective(1, -f2);
-		solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
-		solution.setConstraint(2, c3 <= 0.0 ? 0.0 : c3);
-		solution.setConstraint(3, c4 <= 0.0 ? 0.0 : c4);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
+		solution.setConstraint(2, Constraint.lessThanOrEqual(c3, 0.0));
+		solution.setConstraint(3, Constraint.lessThanOrEqual(c4, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Kita.java
+++ b/src/org/moeaframework/problem/misc/Kita.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -64,9 +65,9 @@ public class Kita extends AbstractProblem {
 		
 		solution.setObjective(0, -f1);
 		solution.setObjective(1, -f2);
-		solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
-		solution.setConstraint(2, c3 <= 0.0 ? 0.0 : c3);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
+		solution.setConstraint(2, Constraint.lessThanOrEqual(c3, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Obayashi.java
+++ b/src/org/moeaframework/problem/misc/Obayashi.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.EncodingUtils;
@@ -62,7 +63,7 @@ public class Obayashi extends AbstractProblem implements AnalyticalProblem {
 		
 		solution.setObjective(0, -x);
 		solution.setObjective(1, -y);
-		solution.setConstraint(0, c <= 0.0 ? 0.0 : c);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Osyczka.java
+++ b/src/org/moeaframework/problem/misc/Osyczka.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -61,8 +62,8 @@ public class Osyczka extends AbstractProblem {
 		
 		solution.setObjective(0, f1);
 		solution.setObjective(1, f2);
-		solution.setConstraint(0, c1 >= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 >= 0.0 ? 0.0 : c2);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.greaterThanOrEqual(c2, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Osyczka2.java
+++ b/src/org/moeaframework/problem/misc/Osyczka2.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -72,12 +73,12 @@ public class Osyczka2 extends AbstractProblem {
 		
 		solution.setObjective(0, f1);
 		solution.setObjective(1, f2);
-		solution.setConstraint(0, c1 >= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 >= 0.0 ? 0.0 : c2);
-		solution.setConstraint(2, c3 >= 0.0 ? 0.0 : c3);
-		solution.setConstraint(3, c4 >= 0.0 ? 0.0 : c4);
-		solution.setConstraint(4, c5 >= 0.0 ? 0.0 : c5);
-		solution.setConstraint(5, c6 >= 0.0 ? 0.0 : c6);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.greaterThanOrEqual(c2, 0.0));
+		solution.setConstraint(2, Constraint.greaterThanOrEqual(c3, 0.0));
+		solution.setConstraint(3, Constraint.greaterThanOrEqual(c4, 0.0));
+		solution.setConstraint(4, Constraint.greaterThanOrEqual(c5, 0.0));
+		solution.setConstraint(5, Constraint.greaterThanOrEqual(c6, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Srinivas.java
+++ b/src/org/moeaframework/problem/misc/Srinivas.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -61,8 +62,8 @@ public class Srinivas extends AbstractProblem {
 		
 		solution.setObjective(0, f1);
 		solution.setObjective(1, f2);
-		solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Tamaki.java
+++ b/src/org/moeaframework/problem/misc/Tamaki.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -58,7 +59,7 @@ public class Tamaki extends AbstractProblem {
 		solution.setObjective(0, -x);
 		solution.setObjective(1, -y);
 		solution.setObjective(2, -z);
-		solution.setConstraint(0, c <= 0.0 ? 0.0 : c);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Tanaka.java
+++ b/src/org/moeaframework/problem/misc/Tanaka.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -56,8 +57,8 @@ public class Tanaka extends AbstractProblem {
 		
 		solution.setObjective(0, x);
 		solution.setObjective(1, y);
-		solution.setConstraint(0, c1 <= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 <= 0.0 ? 0.0 : c2);
+		solution.setConstraint(0, Constraint.lessThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.lessThanOrEqual(c2, 0.0));
 	}
 
 	@Override

--- a/src/org/moeaframework/problem/misc/Viennet4.java
+++ b/src/org/moeaframework/problem/misc/Viennet4.java
@@ -17,6 +17,7 @@
  */
 package org.moeaframework.problem.misc;
 
+import org.moeaframework.core.Constraint;
 import org.moeaframework.core.Solution;
 import org.moeaframework.core.variable.RealVariable;
 import org.moeaframework.problem.AbstractProblem;
@@ -67,9 +68,9 @@ public class Viennet4 extends AbstractProblem {
 		solution.setObjective(0, f1);
 		solution.setObjective(1, f2);
 		solution.setObjective(2, f3);
-		solution.setConstraint(0, c1 >= 0.0 ? 0.0 : c1);
-		solution.setConstraint(1, c2 >= 0.0 ? 0.0 : c2);
-		solution.setConstraint(2, c3 >= 0.0 ? 0.0 : c3);
+		solution.setConstraint(0, Constraint.greaterThanOrEqual(c1, 0.0));
+		solution.setConstraint(1, Constraint.greaterThanOrEqual(c2, 0.0));
+		solution.setConstraint(2, Constraint.greaterThanOrEqual(c3, 0.0));
 	}
 
 	@Override

--- a/test/org/moeaframework/core/ConstraintTest.java
+++ b/test/org/moeaframework/core/ConstraintTest.java
@@ -69,13 +69,13 @@ public class ConstraintTest {
 	public void testGreaterThanOrEqual() {
 		Assert.assertEquals(0.0, Constraint.greaterThanOrEqual(5.0, 5.0), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.greaterThanOrEqual(5.1, 5.0), Settings.EPS);
-		Assert.assertEquals(0.1, Constraint.greaterThanOrEqual(4.9, 5.0), Settings.EPS);
+		Assert.assertEquals(-0.1, Constraint.greaterThanOrEqual(4.9, 5.0), Settings.EPS);
 		
 		Assert.assertEquals(0.0, Constraint.greaterThanOrEqual(5.0, 5.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.greaterThanOrEqual(5.1, 5.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.greaterThanOrEqual(4.9, 5.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.greaterThanOrEqual(5.2, 5.0, 0.1), Settings.EPS);
-		Assert.assertEquals(0.2, Constraint.greaterThanOrEqual(4.8, 5.0, 0.1), Settings.EPS);
+		Assert.assertEquals(-0.2, Constraint.greaterThanOrEqual(4.8, 5.0, 0.1), Settings.EPS);
 	}
 	
 	@Test
@@ -93,41 +93,42 @@ public class ConstraintTest {
 	
 	@Test
 	public void testGreaterThan() {
-		Assert.assertEquals(Math.nextUp(0.0), Constraint.greaterThan(5.0, 5.0), Settings.EPS);
+		Assert.assertEquals(Math.nextDown(0.0), Constraint.greaterThan(5.0, 5.0), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.greaterThan(5.1, 5.0), Settings.EPS);
-		Assert.assertEquals(0.1, Constraint.greaterThan(4.9, 5.0), Settings.EPS);
+		Assert.assertEquals(-0.1, Constraint.greaterThan(4.9, 5.0), Settings.EPS);
 		
-		Assert.assertEquals(Math.nextUp(0.0), Constraint.greaterThan(5.0, 5.0, 0.1), Settings.EPS);
-		Assert.assertEquals(0.1, Constraint.greaterThan(5.1, 5.0, 0.1), Settings.EPS);
-		Assert.assertEquals(0.1, Constraint.greaterThan(4.9, 5.0, 0.1), Settings.EPS);
+		Assert.assertEquals(Math.nextDown(0.0), Constraint.greaterThan(5.0, 5.0, 0.1), Settings.EPS);
+		Assert.assertEquals(-0.1, Constraint.greaterThan(5.1, 5.0, 0.1), Settings.EPS);
+		Assert.assertEquals(-0.1, Constraint.greaterThan(4.9, 5.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.greaterThan(5.2, 5.0, 0.1), Settings.EPS);
-		Assert.assertEquals(0.2, Constraint.greaterThan(4.8, 5.0, 0.1), Settings.EPS);
+		Assert.assertEquals(-0.2, Constraint.greaterThan(4.8, 5.0, 0.1), Settings.EPS);
 	}
 	
 	@Test
 	public void testBetween() {
 		Assert.assertEquals(0.0, Constraint.between(5.0, 5.0, 5.0), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.between(4.0, 5.0, 6.0), Settings.EPS);
-		Assert.assertEquals(0.1, Constraint.between(4.0, 3.9, 6.0), Settings.EPS);
+		Assert.assertEquals(-0.1, Constraint.between(4.0, 3.9, 6.0), Settings.EPS);
 		Assert.assertEquals(0.1, Constraint.between(4.0, 6.1, 6.0), Settings.EPS);
 		
 		Assert.assertEquals(0.0, Constraint.between(5.0, 5.0, 5.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.between(4.0, 3.91, 6.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.between(4.0, 6.09, 6.0, 0.1), Settings.EPS);
-		Assert.assertEquals(0.2, Constraint.between(4.0, 3.8, 6.0, 0.1), Settings.EPS);
+		Assert.assertEquals(-0.2, Constraint.between(4.0, 3.8, 6.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.2, Constraint.between(4.0, 6.2, 6.0, 0.1), Settings.EPS);
 	}
 	
 	@Test
 	public void testOutside() {
 		Assert.assertEquals(Math.nextUp(0.0), Constraint.outside(5.0, 5.0, 5.0), Settings.EPS);
-		Assert.assertEquals(1.0, Constraint.outside(4.0, 5.0, 6.0), Settings.EPS);
+		Assert.assertEquals(0.5, Constraint.outside(4.0, 4.5, 6.0), Settings.EPS);
+		Assert.assertEquals(-0.5, Constraint.outside(4.0, 5.5, 6.0), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.outside(4.0, 3.9, 6.0), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.outside(4.0, 6.1, 6.0), Settings.EPS);
 		
 		Assert.assertEquals(Math.nextUp(0.0), Constraint.outside(5.0, 5.0, 5.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.09, Constraint.outside(4.0, 3.91, 6.0, 0.1), Settings.EPS);
-		Assert.assertEquals(0.09, Constraint.outside(4.0, 6.09, 6.0, 0.1), Settings.EPS);
+		Assert.assertEquals(-0.09, Constraint.outside(4.0, 6.09, 6.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.outside(4.0, 3.8, 6.0, 0.1), Settings.EPS);
 		Assert.assertEquals(0.0, Constraint.outside(4.0, 6.2, 6.0, 0.1), Settings.EPS);
 	}


### PR DESCRIPTION
All test problems now use the `Constraint` class.  This resulted in some of the signs flipping as the `Constraint` class was returning the absolute value.  Therefore, to remain consistent with the historical behavior, some constraints now return negative values.

Another way to interpret the constraints is a positive value indicates the violation is "to the right" of the target on the real number line, and a negative value indicates the violation is "to the left" of the target.