### PR TITLE
Improve performance indicator calculations

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -33,7 +33,7 @@ We can also measure the quality of the resulting Pareto non-dominated solutions 
 indicators, such as Hypervolume.  The `Indicators` class is a convenient way to calculate and display the
 performance indicator values.  We can select specific indicators or enable all.
 
-<!-- java:examples/Example2.java [37:49] -->
+<!-- java:examples/Example2.java [36:48] -->
 
 ```java
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -33,10 +33,9 @@ We can also measure the quality of the resulting Pareto non-dominated solutions 
 indicators, such as Hypervolume.  The `Indicators` class is a convenient way to calculate and display the
 performance indicator values.  We can select specific indicators or enable all.
 
-<!-- java:examples/Example2.java [36:48] -->
+<!-- java:examples/Example2.java [37:48] -->
 
 ```java
-
 Problem problem = new DTLZ2(2);
 
 NSGAII algorithm = new NSGAII(problem);

--- a/docs/example.md
+++ b/docs/example.md
@@ -27,6 +27,46 @@ Var1     Var2     Var3     Var4     Var5     Var6     Var7     Var8     Var9    
 0.808070 0.507494 0.505370 0.488540 0.495386 0.506386 0.503131 0.502002 0.502372 0.503923 0.501195 0.297031 0.955197 
 ```
 
+## Performance indicators
+
+We can also measure the quality of the resulting Pareto non-dominated solutions using one or more performance
+indicators, such as Hypervolume.  The `Indicators` class is a convenient way to calculate and display the
+performance indicator values.  We can select specific indicators or enable all.
+
+<!-- java:examples/Example2.java [37:49] -->
+
+```java
+
+Problem problem = new DTLZ2(2);
+
+NSGAII algorithm = new NSGAII(problem);
+algorithm.run(10000);
+
+NondominatedPopulation approximationSet = algorithm.getResult();
+
+NondominatedPopulation referenceSet = PopulationIO.readReferenceSet("pf/DTLZ2.2D.pf");
+
+Indicators indicator = Indicators.all(problem, referenceSet);
+indicator.apply(approximationSet).display();
+```
+
+<!-- output:examples/Example2.java -->
+
+```
+Indicator                    Value    
+---------------------------- -------- 
+Hypervolume                  0.209259 
+GenerationalDistance         0.000987 
+InvertedGenerationalDistance 0.004388 
+AdditiveEpsilonIndicator     0.008974 
+Spacing                      0.005820 
+MaximumParetoFrontError      0.039554 
+Contribution                 0.000000 
+R1                           0.471058 
+R2                           0.000258 
+R3                           0.000389 
+```
+
 ## Configuring Algorithms
 
 While this looks simple, there is a lot going on behind the scenes.  When we create a new instance of the NSGA-II algorithm, it 

--- a/docs/example.md
+++ b/docs/example.md
@@ -46,8 +46,8 @@ NondominatedPopulation approximationSet = algorithm.getResult();
 
 NondominatedPopulation referenceSet = PopulationIO.readReferenceSet("pf/DTLZ2.2D.pf");
 
-Indicators indicator = Indicators.all(problem, referenceSet);
-indicator.apply(approximationSet).display();
+Indicators indicators = Indicators.all(problem, referenceSet);
+indicators.apply(approximationSet).display();
 ```
 
 <!-- output:examples/Example2.java -->

--- a/docs/news.md
+++ b/docs/news.md
@@ -2,6 +2,14 @@
 
 This page documents notable changes introduced in each chronological release of the MOEA Framework.
 
+## Version 3.12 (TBD)
+
+  * Adds the `Indicators` class to simplify calculating performance indicators, which will eventually
+    replace the older `QualityIndicator` class.  See `Example2.java` for a demo.
+    
+  * Adds ability to scope properties within a try-with-resources block.
+
+
 ## Version 3.11 (04 Mar 2024)
 
   * Removes the `setInitialPopulationSize` method and corresponding `populationSize` parameter

--- a/examples/Example2.java
+++ b/examples/Example2.java
@@ -26,10 +26,9 @@ import org.moeaframework.problem.DTLZ.DTLZ2;
 
 /**
  * Quality indicators are used to compare results between different algorithms.  Here,
- * we calculate the hypervolume and generational distance relative to a reference set.
- * 
- * These reference sets contain optimal solutions to the problem.  Reference sets for
- * most test problems can be found in the ./pf/ directory.
+ * we calculate the indicators in relation to a known reference set. These reference sets
+ * contain optimal solutions to the problem.  Reference sets for most test problems can
+ * be found in the ./pf/ directory.
  */
 public class Example2 {
 

--- a/examples/Example2.java
+++ b/examples/Example2.java
@@ -45,8 +45,8 @@ public class Example2 {
 		// load the reference set and evaluate the quality indicators
 		NondominatedPopulation referenceSet = PopulationIO.readReferenceSet("pf/DTLZ2.2D.pf");
 		
-		Indicators indicator = Indicators.all(problem, referenceSet);
-		indicator.apply(approximationSet).display();
+		Indicators indicators = Indicators.all(problem, referenceSet);
+		indicators.apply(approximationSet).display();
 	}
 
 }

--- a/examples/Example2.java
+++ b/examples/Example2.java
@@ -21,8 +21,7 @@ import org.moeaframework.algorithm.NSGAII;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.PopulationIO;
 import org.moeaframework.core.Problem;
-import org.moeaframework.core.indicator.GenerationalDistance;
-import org.moeaframework.core.indicator.Hypervolume;
+import org.moeaframework.core.indicator.Indicators;
 import org.moeaframework.problem.DTLZ.DTLZ2;
 
 /**
@@ -41,15 +40,13 @@ public class Example2 {
 		NSGAII algorithm = new NSGAII(problem);
 		algorithm.run(10000);
 		
-		NondominatedPopulation result = algorithm.getResult();
+		NondominatedPopulation approximationSet = algorithm.getResult();
 		
 		// load the reference set and evaluate the quality indicators
 		NondominatedPopulation referenceSet = PopulationIO.readReferenceSet("pf/DTLZ2.2D.pf");
-		Hypervolume hypervolume = new Hypervolume(problem, referenceSet);
-		GenerationalDistance gd = new GenerationalDistance(problem, referenceSet);
 		
-		System.out.format("Hypervolume: %.6f%n", hypervolume.evaluate(result));
-		System.out.format("GD: %.6f%n", gd.evaluate(result));
+		Indicators indicator = Indicators.all(problem, referenceSet);
+		indicator.apply(approximationSet).display();
 	}
 
 }

--- a/examples/Example3.java
+++ b/examples/Example3.java
@@ -33,8 +33,8 @@ public class Example3 {
 
 	public static void main(String[] args) throws IOException {
 		Problem problem = new DTLZ2(2);
-		NSGAII algorithm = new NSGAII(problem);
 		
+		NSGAII algorithm = new NSGAII(problem);
 		algorithm.setInitialPopulationSize(250);
 		algorithm.setVariation(new PCX(5, 2));
 		algorithm.setArchive(new EpsilonBoxDominanceArchive(0.01));

--- a/src/org/moeaframework/Analyzer.java
+++ b/src/org/moeaframework/Analyzer.java
@@ -228,14 +228,13 @@ public class Analyzer extends ProblemBuilder implements Displayable {
 	}
 	
 	@Override
-	public Analyzer withProblemClass(Class<?> problemClass, 
-			Object... problemArguments) {
+	public Analyzer withProblemClass(Class<?> problemClass, Object... problemArguments) {
 		return (Analyzer)super.withProblemClass(problemClass, problemArguments);
 	}
 
 	@Override
-	public Analyzer withProblemClass(String problemClassName, 
-			Object... problemArguments) throws ClassNotFoundException {
+	public Analyzer withProblemClass(String problemClassName, Object... problemArguments)
+			throws ClassNotFoundException {
 		return (Analyzer)super.withProblemClass(problemClassName, problemArguments);
 	}
 	
@@ -786,8 +785,7 @@ public class Analyzer extends ProblemBuilder implements Displayable {
 			AnalyzerResults analyzerResults = new AnalyzerResults();
 			
 			for (String algorithm : data.keySet()) {
-				AlgorithmResult algorithmResult = new AlgorithmResult(
-						algorithm);
+				AlgorithmResult algorithmResult = new AlgorithmResult(algorithm);
 				
 				for (Indicator indicator : indicators) {
 					String indicatorName = indicator.getClass().getSimpleName();
@@ -914,8 +912,7 @@ public class Analyzer extends ProblemBuilder implements Displayable {
 		private final List<AlgorithmResult> algorithmResults;
 		
 		/**
-		 * Constructs a new, empty object for storing the results from this
-		 * analyzer.
+		 * Constructs a new, empty object for storing the results from this analyzer.
 		 */
 		AnalyzerResults() {
 			super();
@@ -955,8 +952,7 @@ public class Analyzer extends ProblemBuilder implements Displayable {
 		}
 		
 		/**
-		 * Adds the results for an algorithm.  Each result should have a unique
-		 * algorithm name.
+		 * Adds the results for an algorithm.  Each result should have a unique algorithm name.
 		 * 
 		 * @param result the results for the algorithm
 		 */

--- a/src/org/moeaframework/analysis/collector/IndicatorCollector.java
+++ b/src/org/moeaframework/analysis/collector/IndicatorCollector.java
@@ -123,6 +123,7 @@ public class IndicatorCollector implements Collector {
 	 * 
 	 * @param observation the observation
 	 * @param type the class type of the indicator
+	 * @param <T> the type of indicator
 	 * @return the indicator value
 	 */
 	public static <T extends Indicator> double getIndicatorValue(Observation observation, Class<T> type) {

--- a/src/org/moeaframework/analysis/sensitivity/Evaluator.java
+++ b/src/org/moeaframework/analysis/sensitivity/Evaluator.java
@@ -30,7 +30,7 @@ import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Problem;
-import org.moeaframework.core.indicator.QualityIndicator;
+import org.moeaframework.core.indicator.Indicators;
 import org.moeaframework.core.spi.AlgorithmFactory;
 import org.moeaframework.problem.TimingProblem;
 import org.moeaframework.util.CommandLineUtility;
@@ -193,9 +193,9 @@ public class Evaluator extends CommandLineUtility {
 			try {
 				if (commandLine.hasOption("metrics")) {
 					NondominatedPopulation referenceSet = OptionUtils.getReferenceSet(commandLine);
-					QualityIndicator indicator = new QualityIndicator(problem, referenceSet);
+					Indicators indicators = Indicators.standard(problem, referenceSet);
 
-					output = new MetricFileWriter(indicator, outputFile);
+					output = new MetricFileWriter(indicators, outputFile);
 				} else {
 					output = new ResultFileWriter(problem, outputFile, ResultFileWriterSettings.from(commandLine));
 				}

--- a/src/org/moeaframework/analysis/sensitivity/MetricFileWriter.java
+++ b/src/org/moeaframework/analysis/sensitivity/MetricFileWriter.java
@@ -40,6 +40,7 @@ import org.moeaframework.util.io.FileUtils;
  * 
  * @see MetricFileReader
  */
+@SuppressWarnings("deprecation")
 public class MetricFileWriter implements OutputWriter {
 	
 	/**
@@ -93,7 +94,7 @@ public class MetricFileWriter implements OutputWriter {
 	@Deprecated
 	public MetricFileWriter(QualityIndicator qualityIndicator, File file, MetricFileWriterSettings settings)
 			throws IOException {
-		this(Indicators.from(qualityIndicator), file, settings);
+		this(Indicators.of(qualityIndicator), file, settings);
 	}
 	
 	/**

--- a/src/org/moeaframework/analysis/sensitivity/MetricFileWriter.java
+++ b/src/org/moeaframework/analysis/sensitivity/MetricFileWriter.java
@@ -103,7 +103,7 @@ public class MetricFileWriter implements OutputWriter {
 	 * records the number of correct lines in the file. The {@link #getNumberOfEntries()} can then be used to
 	 * resume evaluation from the last recorded entry.
 	 * 
-	 * @param qualityIndicator the indicators to evaluate
+	 * @param indicators the indicators to evaluate
 	 * @param file the file to which the metrics are written
 	 * @throws IOException if an I/O error occurred
 	 */

--- a/src/org/moeaframework/analysis/sensitivity/ResultFileEvaluator.java
+++ b/src/org/moeaframework/analysis/sensitivity/ResultFileEvaluator.java
@@ -18,6 +18,7 @@
 package org.moeaframework.analysis.sensitivity;
 
 import java.io.File;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -25,7 +26,7 @@ import org.moeaframework.core.FrameworkException;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
-import org.moeaframework.core.indicator.QualityIndicator;
+import org.moeaframework.core.indicator.Indicators;
 import org.moeaframework.util.CommandLineUtility;
 
 /**
@@ -136,7 +137,7 @@ public class ResultFileEvaluator extends CommandLineUtility {
 				}
 			}
 
-			QualityIndicator indicator = new QualityIndicator(problem, referenceSet);
+			Indicators indicator = Indicators.standard(problem, referenceSet);
 
 			try (ResultFileReader reader = new ResultFileReader(problem, inputFile);
 					MetricFileWriter writer = new MetricFileWriter(indicator, outputFile)) {

--- a/src/org/moeaframework/core/Settings.java
+++ b/src/org/moeaframework/core/Settings.java
@@ -26,8 +26,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringTokenizer;
@@ -545,6 +547,172 @@ public class Settings {
 		}
 		
 		return sb.toString();
+	}
+	
+	/**
+	 * Returns a scope that can temporary change settings.  Any settings modified by calling {@link Scope#with}
+	 * will be reverted to their original values when leaving the scope.
+	 * 
+	 * @return the scope
+	 */
+	public static Scope createScope() {
+		return new Scope();
+	}
+	
+	/**
+	 * Defines settings within a temporary scope, where any overridden settings are reset after existing the
+	 * scope.  Typically used within a try-with-resources block, allowing the settings to be reverted
+	 * automatically when exiting the body.
+	 */
+	public static class Scope implements AutoCloseable {
+		
+		/**
+		 * The keys that are modified in this scope.
+		 */
+		private final Set<String> modifiedKeys;
+		
+		/**
+		 * The original values that will be restored when exiting the scope.
+		 */
+		private final TypedProperties originalValues;
+		
+		/**
+		 * Constructs a new scope.
+		 */
+		public Scope() {
+			super();
+			this.modifiedKeys = new HashSet<String>();
+			this.originalValues = new TypedProperties();
+		}
+		
+		/**
+		 * Captures the current value of the setting.
+		 * 
+		 * @param key the key of the setting
+		 */
+		private void capture(String key) {
+			modifiedKeys.add(key);
+			
+			if (Settings.PROPERTIES.contains(key)) {
+				originalValues.setString(key, Settings.PROPERTIES.getString(key));
+			}
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, double value) {
+			capture(key);
+			Settings.PROPERTIES.setDouble(key, value);
+			return this;
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, float value) {
+			capture(key);
+			Settings.PROPERTIES.setFloat(key, value);
+			return this;
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, long value) {
+			capture(key);
+			Settings.PROPERTIES.setLong(key, value);
+			return this;
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, int value) {
+			capture(key);
+			Settings.PROPERTIES.setInt(key, value);
+			return this;
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, short value) {
+			capture(key);
+			Settings.PROPERTIES.setShort(key, value);
+			return this;
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, byte value) {
+			capture(key);
+			Settings.PROPERTIES.setByte(key, value);
+			return this;
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, boolean value) {
+			capture(key);
+			Settings.PROPERTIES.setBoolean(key, value);
+			return this;
+		}
+		
+		/**
+		 * Temporarily overrides the given key within the scope.
+		 * 
+		 * @param key the key
+		 * @param value the value
+		 * @return a reference to this scope for chaining multiple calls together
+		 */
+		public Scope with(String key, String value) {
+			capture(key);
+			Settings.PROPERTIES.setString(key, value);
+			return this;
+		}
+
+		@Override
+		public void close() {
+			for (String key : modifiedKeys) {
+				Settings.PROPERTIES.remove(key);
+				
+				if (originalValues.contains(key)) {
+					Settings.PROPERTIES.setString(key, originalValues.getString(key));
+				}
+			}
+		}
+				
 	}
 	
 }

--- a/src/org/moeaframework/core/Settings.java
+++ b/src/org/moeaframework/core/Settings.java
@@ -26,11 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringTokenizer;
 import org.moeaframework.analysis.sensitivity.OutputWriter;
@@ -38,6 +35,7 @@ import org.moeaframework.core.NondominatedPopulation.DuplicateMode;
 import org.moeaframework.core.indicator.Hypervolume;
 import org.moeaframework.core.spi.AlgorithmFactory;
 import org.moeaframework.core.spi.ProblemFactory;
+import org.moeaframework.util.PropertyScope;
 import org.moeaframework.util.TypedProperties;
 
 /**
@@ -550,169 +548,13 @@ public class Settings {
 	}
 	
 	/**
-	 * Returns a scope that can temporary change settings.  Any settings modified by calling {@link Scope#with}
-	 * will be reverted to their original values when leaving the scope.
+	 * Creates a new scope wherein settings can be temporarily modified.  Upon closing the scope, the original
+	 * settings are restored.
 	 * 
 	 * @return the scope
 	 */
-	public static Scope createScope() {
-		return new Scope();
-	}
-	
-	/**
-	 * Defines settings within a temporary scope, where any overridden settings are reset after existing the
-	 * scope.  Typically used within a try-with-resources block, allowing the settings to be reverted
-	 * automatically when exiting the body.
-	 */
-	public static class Scope implements AutoCloseable {
-		
-		/**
-		 * The keys that are modified in this scope.
-		 */
-		private final Set<String> modifiedKeys;
-		
-		/**
-		 * The original values that will be restored when exiting the scope.
-		 */
-		private final TypedProperties originalValues;
-		
-		/**
-		 * Constructs a new scope.
-		 */
-		public Scope() {
-			super();
-			this.modifiedKeys = new HashSet<String>();
-			this.originalValues = new TypedProperties();
-		}
-		
-		/**
-		 * Captures the current value of the setting.
-		 * 
-		 * @param key the key of the setting
-		 */
-		private void capture(String key) {
-			modifiedKeys.add(key);
-			
-			if (Settings.PROPERTIES.contains(key)) {
-				originalValues.setString(key, Settings.PROPERTIES.getString(key));
-			}
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, double value) {
-			capture(key);
-			Settings.PROPERTIES.setDouble(key, value);
-			return this;
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, float value) {
-			capture(key);
-			Settings.PROPERTIES.setFloat(key, value);
-			return this;
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, long value) {
-			capture(key);
-			Settings.PROPERTIES.setLong(key, value);
-			return this;
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, int value) {
-			capture(key);
-			Settings.PROPERTIES.setInt(key, value);
-			return this;
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, short value) {
-			capture(key);
-			Settings.PROPERTIES.setShort(key, value);
-			return this;
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, byte value) {
-			capture(key);
-			Settings.PROPERTIES.setByte(key, value);
-			return this;
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, boolean value) {
-			capture(key);
-			Settings.PROPERTIES.setBoolean(key, value);
-			return this;
-		}
-		
-		/**
-		 * Temporarily overrides the given key within the scope.
-		 * 
-		 * @param key the key
-		 * @param value the value
-		 * @return a reference to this scope for chaining multiple calls together
-		 */
-		public Scope with(String key, String value) {
-			capture(key);
-			Settings.PROPERTIES.setString(key, value);
-			return this;
-		}
-
-		@Override
-		public void close() {
-			for (String key : modifiedKeys) {
-				Settings.PROPERTIES.remove(key);
-				
-				if (originalValues.contains(key)) {
-					Settings.PROPERTIES.setString(key, originalValues.getString(key));
-				}
-			}
-		}
-				
+	public static PropertyScope createScope() {
+		return new PropertyScope(PROPERTIES);
 	}
 	
 }

--- a/src/org/moeaframework/core/indicator/Indicators.java
+++ b/src/org/moeaframework/core/indicator/Indicators.java
@@ -1,0 +1,583 @@
+package org.moeaframework.core.indicator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.moeaframework.core.NondominatedPopulation;
+import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
+import org.moeaframework.core.configuration.Validate;
+import org.moeaframework.util.TypedProperties;
+import org.moeaframework.util.format.Column;
+import org.moeaframework.util.format.Formattable;
+import org.moeaframework.util.format.TabularData;
+
+/**
+ * Helper for evaluating multiple performance indicators, primarily for avoiding repetitive calculations that
+ * would occur if creating each indicator separately.
+ */
+public class Indicators implements Function<NondominatedPopulation, Indicators.IndicatorValues> {
+
+	/**
+	 * Creates an instance of this class that evaluates all performance indicators.
+	 * 
+	 * @param problem the problem
+	 * @param referenceSet the reference set
+	 * @return the constructed instance
+	 */
+	public static Indicators all(Problem problem, NondominatedPopulation referenceSet) {
+		return from(problem, referenceSet).includeAllMetrics();
+	}
+	
+	/**
+	 * Creates an instance of this class that evaluates all standard performance indicators.  This
+	 * excludes the R-indicators.
+	 * 
+	 * @param problem the problem
+	 * @param referenceSet the reference set
+	 * @return the constructed instance
+	 */
+	public static Indicators standard(Problem problem, NondominatedPopulation referenceSet) {
+		return from(problem, referenceSet).includeStandardMetrics();
+	}
+
+	/**
+	 * Creates a new instance of this class with no configured indicators.
+	 * 
+	 * @param problem the problem
+	 * @param referenceSet the reference set
+	 * @return the constructed instance
+	 */
+	public static Indicators from(Problem problem, NondominatedPopulation referenceSet) {
+		return new Indicators(problem, referenceSet);
+	}
+	
+	/**
+	 * Creates an instance of this class mirroring the given quality indicator.  This method simplifies
+	 * transitioning away from the old, deprecated {@link QualityIndicator} class.
+	 * 
+	 * @param qualityIndicator the quality indicator
+	 * @return the constructed instance
+	 */
+	public static Indicators from(QualityIndicator qualityIndicator) {
+		return new Indicators(qualityIndicator.getProblem(), qualityIndicator.getReferenceSet())
+				.includeStandardMetrics();
+	}
+
+	/**
+	 * The problem.
+	 */
+	private final Problem problem;
+
+	/**
+	 * The reference set for the problem.
+	 */
+	private final NondominatedPopulation referenceSet;
+
+	/**
+	 * The normalized reference set.
+	 */
+	private final NondominatedPopulation normalizedReferenceSet;
+
+	/**
+	 * The normalizer to normalize populations so that all objectives reside in the range {@code [0, 1]}.
+	 */
+	private final Normalizer normalizer;
+
+	/**
+	 * {@code true} if the hypervolume metric is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeHypervolume;
+
+	/**
+	 * {@code true} if the generational distance metric is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeGenerationalDistance;
+
+	/**
+	 * {@code true} if the inverted generational distance metric is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeInvertedGenerationalDistance;
+
+	/**
+	 * {@code true} if the additive &epsilon;-indicator metric is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeAdditiveEpsilonIndicator;
+
+	/**
+	 * {@code true} if the spacing metric is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeSpacing;
+
+	/**
+	 * {@code true} if the maximum Pareto front error metric is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeMaximumParetoFrontError;
+
+	/**
+	 * {@code true} if the contribution of each approximation set to the reference set is to be computed;
+	 * {@code false} otherwise.
+	 */
+	private boolean includeContribution;
+
+	/**
+	 * {@code true} if the R1 indicator is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeR1;
+
+	/**
+	 * {@code true} if the R2 indicator is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeR2;
+
+	/**
+	 * {@code true} if the R3 indicator is to be computed; {@code false} otherwise.
+	 */
+	private boolean includeR3;
+
+	/**
+	 * The &epsilon; values used by the indicators.
+	 */
+	private double[] epsilon;
+	
+	/**
+	 * The number of subdivisions used by the R indicators.  If unset, will use the default from
+	 * {@link RIndicator#getDefaultSubdivisions(Problem)}.
+	 */
+	private Optional<Integer> subdivisions;
+
+	/**
+	 * The cached hypervolume indicator.
+	 */
+	private Hypervolume hypervolume;
+
+	/**
+	 * The cached contribution indicator.
+	 */
+	private Contribution contribution;
+
+	/**
+	 * The cached R1 indicator.
+	 */
+	private R1Indicator r1;
+
+	/**
+	 * The cached R2 indicator.
+	 */
+	private R2Indicator r2;
+
+	/**
+	 * The cached R3 indicator.
+	 */
+	private R3Indicator r3;
+
+	/**
+	 * Constructs a new Indicators object for the given problem.
+	 * 
+	 * @param problem the problem
+	 * @param referenceSet the reference set
+	 */
+	public Indicators(Problem problem, NondominatedPopulation referenceSet) {
+		super();
+		this.problem = problem;
+		this.referenceSet = referenceSet;
+
+		normalizer = new Normalizer(problem, referenceSet);
+		normalizedReferenceSet = normalizer.normalize(referenceSet);
+		
+		subdivisions = Optional.empty();
+	}
+
+	@Override
+	public IndicatorValues apply(NondominatedPopulation approximationSet) {
+		IndicatorValues result = new IndicatorValues(approximationSet);
+		NondominatedPopulation normalizedApproximationSet = normalizer.normalize(approximationSet);
+
+		if (includeHypervolume) {
+			if (hypervolume == null) {
+				hypervolume = new Hypervolume(problem, referenceSet);
+			}
+
+			result.hypervolume = hypervolume.evaluate(approximationSet);
+		}
+
+		if (includeGenerationalDistance) {
+			result.generationalDistance = GenerationalDistance.evaluate(problem, normalizedApproximationSet,
+					normalizedReferenceSet, Settings.getGDPower());
+		}
+
+		if (includeInvertedGenerationalDistance) {
+			result.invertedGenerationalDistance = InvertedGenerationalDistance.evaluate(problem,
+					normalizedApproximationSet, normalizedReferenceSet, Settings.getIGDPower());
+		}
+
+		if (includeAdditiveEpsilonIndicator) {
+			result.additiveEpsilonIndicator = AdditiveEpsilonIndicator.evaluate(problem,
+					normalizedApproximationSet, normalizedReferenceSet);
+		}
+
+		if (includeMaximumParetoFrontError) {
+			result.maximumParetoFrontError = MaximumParetoFrontError.evaluate(problem,
+					normalizedApproximationSet, normalizedReferenceSet);
+		}
+
+		if (includeSpacing) {
+			result.spacing = Spacing.evaluate(problem, approximationSet);
+		}
+
+		if (includeContribution) {
+			if (contribution == null) {
+				contribution = epsilon == null ? new Contribution(referenceSet) : new Contribution(referenceSet, epsilon);
+			}
+
+			result.contribution = contribution.evaluate(approximationSet);
+		}
+
+		if (includeR1) {
+			if (r1 == null) {
+				r1 = new R1Indicator(problem,
+						subdivisions.isPresent() ? subdivisions.get() : RIndicator.getDefaultSubdivisions(problem),
+						referenceSet);
+			}
+
+			result.r1 = r1.evaluate(approximationSet);
+		}
+
+		if (includeR2) {
+			if (r2 == null) {
+				r2 = new R2Indicator(problem,
+						subdivisions.isPresent() ? subdivisions.get() : RIndicator.getDefaultSubdivisions(problem),
+						referenceSet);
+			}
+
+			result.r2 = r2.evaluate(approximationSet);
+		}
+
+		if (includeR3) {
+			if (r3 == null) {
+				r3 = new R3Indicator(problem,
+						subdivisions.isPresent() ? subdivisions.get() : RIndicator.getDefaultSubdivisions(problem),
+						referenceSet);
+			}
+
+			result.r3 = r3.evaluate(approximationSet);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Sets the &epsilon; values used by the indicators.
+	 * 
+	 * @param epsilon the &epsilon; values
+	 * @return a reference to this object
+	 */
+	public Indicators withEpsilon(double... epsilon) {
+		if ((epsilon == null) || (epsilon.length == 0)) {
+			this.epsilon = null;
+		} else {
+			this.epsilon = epsilon;
+		}
+
+		return this;
+	}
+	
+	/**
+	 * Sets the number of subdivisions used by the R-indicators.
+	 * 
+	 * @param subdivisions the number of subdivisions
+	 * @return a reference to this object
+	 */
+	public Indicators withSubdivisions(int subdivisions) {
+		Validate.greaterThan("subdivisions", 1, subdivisions);
+		
+		r1 = null;
+		r2 = null;
+		r3 = null;
+		
+		this.subdivisions = Optional.of(subdivisions);
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the hypervolume metric.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeHypervolume() {
+		includeHypervolume = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the generational distance metric.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeGenerationalDistance() {
+		includeGenerationalDistance = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the inverted generational distance metric.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeInvertedGenerationalDistance() {
+		includeInvertedGenerationalDistance = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the additive &epsilon;-indicator metric.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeAdditiveEpsilonIndicator() {
+		includeAdditiveEpsilonIndicator = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the maximum Pareto front error metric.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeMaximumParetoFrontError() {
+		includeMaximumParetoFrontError = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the spacing metric.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeSpacing() {
+		includeSpacing = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the contribution metric.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeContribution() {
+		includeContribution = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the R1 indicator.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeR1() {
+		includeR1 = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the R2 indicator.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeR2() {
+		includeR2 = true;
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of the R3 indicator.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeR3() {
+		includeR3 = true;
+		return this;
+	}
+	
+	/**
+	 * Enables the evaluation of all standard metrics.  This excludes the R-indicators.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeStandardMetrics() {
+		if (Settings.isHypervolumeEnabled()) {
+			includeHypervolume();
+		}
+
+		includeGenerationalDistance();
+		includeInvertedGenerationalDistance();
+		includeAdditiveEpsilonIndicator();
+		includeMaximumParetoFrontError();
+		includeSpacing();
+		includeContribution();
+		
+		return this;
+	}
+
+	/**
+	 * Enables the evaluation of all metrics.
+	 * 
+	 * @return a reference to this object
+	 */
+	public Indicators includeAllMetrics() {
+		includeStandardMetrics();
+		includeR1();
+		includeR2();
+		includeR3();
+		
+		return this;
+	}
+
+	/**
+	 * Collection of indicator results, with values defaulting to {@value Double#NaN} if not included.
+	 */
+	public static class IndicatorValues implements Formattable<Pair<String, Double>> {
+
+		private final NondominatedPopulation approximationSet;
+
+		private double hypervolume;
+		private double generationalDistance;
+		private double invertedGenerationalDistance;
+		private double additiveEpsilonIndicator;
+		private double spacing;
+		private double maximumParetoFrontError;
+		private double contribution;
+		private double r1;
+		private double r2;
+		private double r3;
+
+		public IndicatorValues(NondominatedPopulation approximationSet) {
+			super();
+			this.approximationSet = approximationSet;
+
+			hypervolume = Double.NaN;
+			generationalDistance = Double.NaN;
+			invertedGenerationalDistance = Double.NaN;
+			additiveEpsilonIndicator = Double.NaN;
+			spacing = Double.NaN;
+			maximumParetoFrontError = Double.NaN;
+			contribution = Double.NaN;
+			r1 = Double.NaN;
+			r2 = Double.NaN;
+			r3 = Double.NaN;
+		}
+
+		public NondominatedPopulation getApproximationSet() {
+			return approximationSet;
+		}
+
+		public double getHypervolume() {
+			return hypervolume;
+		}
+
+		public double getGenerationalDistance() {
+			return generationalDistance;
+		}
+
+		public double getInvertedGenerationalDistance() {
+			return invertedGenerationalDistance;
+		}
+
+		public double getAdditiveEpsilonIndicator() {
+			return additiveEpsilonIndicator;
+		}
+
+		public double getSpacing() {
+			return spacing;
+		}
+
+		public double getMaximumParetoFrontError() {
+			return maximumParetoFrontError;
+		}
+
+		public double getContribution() {
+			return contribution;
+		}
+
+		public double getR1() {
+			return r1;
+		}
+
+		public double getR2() {
+			return r2;
+		}
+
+		public double getR3() {
+			return r3;
+		}
+		
+		public TypedProperties asProperties() {
+			TypedProperties properties = new TypedProperties();
+			
+			for (Pair<String, Double> entry : asList()) {
+				properties.setDouble(entry.getKey(), entry.getValue());
+			}
+			
+			return properties;
+		}
+
+		@Override
+		public TabularData<Pair<String, Double>> asTabularData() {
+			TabularData<Pair<String, Double>> data = new TabularData<Pair<String, Double>>(asList());
+			data.addColumn(new Column<Pair<String, Double>, String>("Indicator", p -> p.getKey()));
+			data.addColumn(new Column<Pair<String, Double>, Double>("Value", p -> p.getValue()));
+			return data;
+		}
+		
+		private Iterable<Pair<String, Double>> asList() {
+			List<Pair<String, Double>> results = new ArrayList<Pair<String, Double>>();
+
+			if (!Double.isNaN(hypervolume)) {
+				results.add(Pair.of("Hypervolume", hypervolume));
+			}
+
+			if (!Double.isNaN(generationalDistance)) {
+				results.add(Pair.of("GenerationalDistance", generationalDistance));
+			}
+			
+			if (!Double.isNaN(invertedGenerationalDistance)) {
+				results.add(Pair.of("InvertedGenerationalDistance", invertedGenerationalDistance));
+			}
+			
+			if (!Double.isNaN(additiveEpsilonIndicator)) {
+				results.add(Pair.of("AdditiveEpsilonIndicator", additiveEpsilonIndicator));
+			}
+			
+			if (!Double.isNaN(spacing)) {
+				results.add(Pair.of("Spacing", spacing));
+			}
+			
+			if (!Double.isNaN(maximumParetoFrontError)) {
+				results.add(Pair.of("MaximumParetoFrontError", maximumParetoFrontError));
+			}
+			
+			if (!Double.isNaN(contribution)) {
+				results.add(Pair.of("Contribution", contribution));
+			}
+			
+			if (!Double.isNaN(r1)) {
+				results.add(Pair.of("R1", r1));
+			}
+			
+			if (!Double.isNaN(r2)) {
+				results.add(Pair.of("R2", r2));
+			}
+			
+			if (!Double.isNaN(r3)) {
+				results.add(Pair.of("R3", r3));
+			}
+			
+			return results;
+		}
+
+	}
+
+}

--- a/src/org/moeaframework/core/indicator/Indicators.java
+++ b/src/org/moeaframework/core/indicator/Indicators.java
@@ -1,3 +1,20 @@
+/* Copyright 2009-2024 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.moeaframework.core.indicator;
 
 import java.util.ArrayList;

--- a/src/org/moeaframework/core/indicator/QualityIndicator.java
+++ b/src/org/moeaframework/core/indicator/QualityIndicator.java
@@ -23,7 +23,10 @@ import org.moeaframework.core.Settings;
 
 /**
  * Evaluates multiple indicators while avoiding repetitive computations.
+ * 
+ * @deprecated Use {@link Indicators} instead
  */
+@Deprecated
 public class QualityIndicator {
 
 	/**

--- a/src/org/moeaframework/util/OptionCompleter.java
+++ b/src/org/moeaframework/util/OptionCompleter.java
@@ -22,24 +22,22 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Utility for auto-completion, finding the closest matching unique option
- * from a set of options. For instance,
- * 
- * <pre>
+ * Utility for auto-completion, finding the closest matching unique option from a set of options. For instance,
+ * <pre>{@code
  * 	OptionCompleter completer = new OptionCompleter();
- * 	completer.add(&quot;subset&quot;);
- * 	completer.add(&quot;superset&quot;);
- * 	completer.lookup(&quot;sub&quot;); // returns &quot;subset&quot;
- * 	completer.lookup(&quot;sup&quot;); // returns &quot;superset&quot;
- * 	completer.lookup(&quot;s&quot;); // returns null, since both subset and superset match
- * 	completer.lookup(&quot;k&quot;); // returns null, no matches
- * </pre>
+ * 	completer.add("subset");
+ * 	completer.add("superset");
+ * 	completer.lookup("sub");   // returns &quot;subset&quot;
+ * 	completer.lookup("sup");   // returns &quot;superset&quot;
+ * 	completer.lookup("s");     // returns null, since both subset and superset match
+ * 	completer.lookup("k");     // returns null, no matches
+ * }</pre>
  */
 public class OptionCompleter {
 
 	/**
-	 * Collection of options. The map serves to ensure each option is unique
-	 * and caches the value of the option in lowercase.
+	 * Collection of options. The map serves to ensure each option is unique and stores the value of the option
+	 * in lowercase.
 	 */
 	private final Map<String, String> options;
 
@@ -53,8 +51,7 @@ public class OptionCompleter {
 	}
 
 	/**
-	 * Constructs a new option auto-completer initialized to recognize the 
-	 * specified options.
+	 * Constructs a new option auto-completer initialized to recognize the specified options.
 	 * 
 	 * @param options the initial options
 	 */
@@ -67,8 +64,7 @@ public class OptionCompleter {
 	}
 
 	/**
-	 * Constructs a new option auto-completer initialized to recognize the 
-	 * specified options.
+	 * Constructs a new option auto-completer initialized to recognize the specified options.
 	 * 
 	 * @param options the initial options
 	 */
@@ -81,8 +77,7 @@ public class OptionCompleter {
 	}
 
 	/**
-	 * Adds an option to this {@code OptionCompleter}. Duplicate options are
-	 * ignored.
+	 * Adds an option to this {@code OptionCompleter}. Duplicate options are ignored.
 	 * 
 	 * @param option the option
 	 */
@@ -91,13 +86,11 @@ public class OptionCompleter {
 	}
 
 	/**
-	 * Returns the closest matching unique option from the set of options stored
-	 * in this {@code OptionCompleter}. Returns {@code null} if no options
-	 * matched or more than one option matched.
+	 * Returns the closest matching unique option from the set of options stored in this {@code OptionCompleter}.
+	 * Returns {@code null} if no options matched or more than one option matched.
 	 * 
 	 * @param partial the partial/complete option
-	 * @return the closest matching option, or {@code null} if no options
-	 *         matched or more than one option matched
+	 * @return the closest matching option, or {@code null} if no options matched or more than one option matched
 	 */
 	public String lookup(String partial) {
 		String result = null;

--- a/src/org/moeaframework/util/OptionCompleter.java
+++ b/src/org/moeaframework/util/OptionCompleter.java
@@ -27,8 +27,8 @@ import java.util.Map;
  * 	OptionCompleter completer = new OptionCompleter();
  * 	completer.add("subset");
  * 	completer.add("superset");
- * 	completer.lookup("sub");   // returns &quot;subset&quot;
- * 	completer.lookup("sup");   // returns &quot;superset&quot;
+ * 	completer.lookup("sub");   // returns "subset"
+ * 	completer.lookup("sup");   // returns "superset"
  * 	completer.lookup("s");     // returns null, since both subset and superset match
  * 	completer.lookup("k");     // returns null, no matches
  * }</pre>

--- a/src/org/moeaframework/util/PropertyScope.java
+++ b/src/org/moeaframework/util/PropertyScope.java
@@ -1,0 +1,181 @@
+/* Copyright 2009-2024 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.util;
+
+/**
+ * Creates a scope for a {@link TypedProperties}, allowing the properties to be temporarily overridden
+ * within the scope.  These should typically be used within try-with-resources so the scope is automatically
+ * closed when exiting the block.
+ * <pre>
+ *   try (PropertyScope scope = properties.createScope()) {
+ *       // temporarily override properties within scope
+ *       properties.setInt("populationSize", 500);
+ *   }
+ * </pre>
+ */
+public class PropertyScope implements AutoCloseable {
+	
+	/**
+	 * The properties that are covered by this scope.
+	 */
+	private final TypedProperties properties;
+	
+	/**
+	 * The original values that will be restored when closing this scope.
+	 */
+	private final TypedProperties originalValues;
+
+	/**
+	 * Creates a new scope for the properties.
+	 * 
+	 * @param properties the properties
+	 */
+	public PropertyScope(TypedProperties properties) {
+		super();
+		this.properties = properties;
+		
+		originalValues = new TypedProperties();
+		originalValues.addAll(properties);
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, double value) {
+		properties.setDouble(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, float value) {
+		properties.setFloat(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, long value) {
+		properties.setLong(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, int value) {
+		properties.setInt(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, short value) {
+		properties.setShort(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, byte value) {
+		properties.setByte(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, boolean value) {
+		properties.setBoolean(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public <T extends Enum<?>> PropertyScope with(String key, T value) {
+		properties.setEnum(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for setting a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @param value the property value
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope with(String key, String value) {
+		properties.setString(key, value);
+		return this;
+	}
+	
+	/**
+	 * Convenience method for removing a property within the scope.
+	 * 
+	 * @param key the property key
+	 * @return a reference to this scope for chaining multiple calls together
+	 */
+	public PropertyScope without(String key) {
+		properties.remove(key);
+		return this;
+	}
+
+	@Override
+	public void close() {
+		properties.clear();
+		properties.addAll(originalValues);
+	}
+
+}

--- a/src/org/moeaframework/util/PropertyScope.java
+++ b/src/org/moeaframework/util/PropertyScope.java
@@ -142,6 +142,7 @@ public class PropertyScope implements AutoCloseable {
 	 * 
 	 * @param key the property key
 	 * @param value the property value
+	 * @param <T> the enumeration type
 	 * @return a reference to this scope for chaining multiple calls together
 	 */
 	public <T extends Enum<?>> PropertyScope with(String key, T value) {

--- a/src/org/moeaframework/util/RotationMatrixBuilder.java
+++ b/src/org/moeaframework/util/RotationMatrixBuilder.java
@@ -25,25 +25,20 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.moeaframework.core.PRNG;
 
 /**
- * Builds rotation matrices of any dimension constructively from one or more
- * 2D planar rotations.  Three types of construction mechanisms are provided:
- * 
+ * Builds rotation matrices of any dimension constructively from one or more 2D planar rotations.  Three types of
+ * construction mechanisms are provided:
  * <ol>
  *   <li>Specific rotation planes and thetas
- *     <pre>  new RotationMatrixBuilder(3).rotatePlane(0,1).withTheta(Math.PI/4)
- *       .rotatePlane(1,2).withTheta(Math.PI/8).create()</pre>
+ *     <pre>new RotationMatrixBuilder(3).rotatePlane(0,1).withTheta(Math.PI/4).rotatePlane(1,2).withTheta(Math.PI/8).create()</pre>
  *   <li>Specific rotation planes with random thetas
- *     <pre>  new RotationMatrixBuilder(3).rotatePlane(0,1).rotatePlane(1,2)
- *       .withRandomThetas().create()</pre>
+ *     <pre>new RotationMatrixBuilder(3).rotatePlane(0,1).rotatePlane(1,2).withRandomThetas().create()</pre>
  *   <li>Random subplanes with random thetas
- *     <pre>  new RotationMatrixBuilder(3).rotateK(2).create()</pre>
+ *     <pre>new RotationMatrixBuilder(3).rotateK(2).create()</pre>
  * </ol>
- * 
  * <p>
  * References:
  * <ol>
- *   <li>Aguilera, A. and P&eacute;rez-Aguila, R.  "General n-Dimensional 
- *       Rotations."  WSCG 2004, pp. 1-8, 2004.
+ *   <li>Aguilera, A. and P&eacute;rez-Aguila, R.  "General n-Dimensional Rotations."  WSCG 2004, pp. 1-8, 2004.
  * </ol>
  */
 public class RotationMatrixBuilder {
@@ -64,8 +59,7 @@ public class RotationMatrixBuilder {
 		private final int secondAxis;
 		
 		/**
-		 * The rotation angle in radians; or {@code NaN} if no rotation is 
-		 * assigned.
+		 * The rotation angle in radians; or {@code NaN} if no rotation is assigned.
 		 */
 		private double theta;
 		
@@ -102,11 +96,9 @@ public class RotationMatrixBuilder {
 		}
 
 		/**
-		 * Returns the rotation angle in radians; or {@code NaN} if no rotation
-		 * is assigned.
+		 * Returns the rotation angle in radians; or {@code NaN} if no rotation is assigned.
 		 * 
-		 * @return the rotation angle in radians; or {@code NaN} if no rotation
-		 *         is assigned
+		 * @return the rotation angle in radians; or {@code NaN} if no rotation is assigned
 		 */
 		public double getTheta() {
 			return theta;
@@ -136,8 +128,7 @@ public class RotationMatrixBuilder {
 	/**
 	 * Constructs a rotation matrix builder for the given dimension.
 	 * 
-	 * @param dimension the dimension of rotation matrices produced by
-	 *        this builder
+	 * @param dimension the dimension of rotation matrices produced by this builder
 	 */
 	public RotationMatrixBuilder(int dimension) {
 		super();
@@ -147,9 +138,8 @@ public class RotationMatrixBuilder {
 	}
 	
 	/**
-	 * Adds a rotation around the 2D rotation plane defined by the two axes.
-	 * The plane is initially unrotated, but can be assigned a specific rotation
-	 * angle if followed by {@link #withTheta(double)}.
+	 * Adds a rotation around the 2D rotation plane defined by the two axes.  The plane is initially unrotated, but
+	 * can be assigned a specific rotation angle if followed by {@link #withTheta(double)}.
 	 * 
 	 * @param i the first axis
 	 * @param j the second axis
@@ -166,9 +156,8 @@ public class RotationMatrixBuilder {
 	}
 	
 	/**
-	 * Sets the rotation angle, in radians, of the last 2D rotation plane
-	 * added to this builder.  This method should always only follow 
-	 * invocations of {@link #rotatePlane(int, int)}.
+	 * Sets the rotation angle, in radians, of the last 2D rotation plane added to this builder.  This method should
+	 * always only follow  invocations of {@link #rotatePlane(int, int)}.
 	 * 
 	 * @param theta the rotation angle in radians
 	 * @return a reference to this rotation matrix builder
@@ -180,8 +169,7 @@ public class RotationMatrixBuilder {
 	}
 	
 	/**
-	 * Sets the rotation angle, in radians, of all 2D rotation planes added to
-	 * this builder.
+	 * Sets the rotation angle, in radians, of all 2D rotation planes added to this builder.
 	 * 
 	 * @param theta the rotation angle in radians
 	 * @return a reference to this rotation matrix builder
@@ -195,8 +183,7 @@ public class RotationMatrixBuilder {
 	}
 	
 	/**
-	 * Assigns random rotation angles to all 2D rotation planes added to this 
-	 * builder.
+	 * Assigns random rotation angles to all 2D rotation planes added to this builder.
 	 * 
 	 * @return a reference to this rotation matrix builder
 	 */
@@ -226,9 +213,8 @@ public class RotationMatrixBuilder {
 	}
 	
 	/**
-	 * Rotates {@code k} randomly-selected but unique 2D rotation planes and 
-	 * assigns each a random rotation angle.  For an {@code N}-dimension 
-	 * rotation matrix, there exist {@code (N choose 2)} 2D rotation planes.
+	 * Rotates {@code k} randomly-selected but unique 2D rotation planes and  assigns each a random rotation angle.
+	 * For an {@code N}-dimension rotation matrix, there exist {@code (N choose 2)} 2D rotation planes.
 	 * 
 	 * @param k the number of randomly-selected 2D rotation planes
 	 * @return a reference to this rotation matrix builder
@@ -264,11 +250,9 @@ public class RotationMatrixBuilder {
 	}
 	
 	/**
-	 * Returns the rotation matrix resulting from applying all 2D rotation 
-	 * planes and angles added to this builder.
+	 * Returns the rotation matrix resulting from applying all 2D rotation planes and angles added to this builder.
 	 * 
-	 * @return the rotation matrix resulting from applying all 2D rotation 
-	 *         planes and angles added to this builder
+	 * @return the rotation matrix resulting from applying all 2D rotation planes and angles added to this builder
 	 */
 	public RealMatrix create() {
 		RealMatrix rotation = newIdentityMatrix();
@@ -302,14 +286,12 @@ public class RotationMatrixBuilder {
 	}
 	
 	/**
-	 * Returns a rotation matrix for rotating about the 2D plane defined by
-	 * the specified axes.
+	 * Returns a rotation matrix for rotating about the 2D plane defined by the specified axes.
 	 * 
 	 * @param i the first axis
 	 * @param j the second axis
 	 * @param theta the rotation angle in radians
-	 * @return a rotation matrix for rotating about the 2D plane defined by
-	 *         the specified axes
+	 * @return a rotation matrix for rotating about the 2D plane defined by the specified axes
 	 */
 	private RealMatrix newRotationMatrix(int i, int j, double theta) {
 		RealMatrix rotation = newIdentityMatrix();

--- a/src/org/moeaframework/util/Timing.java
+++ b/src/org/moeaframework/util/Timing.java
@@ -24,20 +24,16 @@ import java.util.Map;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 /**
- * Tool to simplify manually collecting timing information. Timers with
- * different names can be interleaved or nested, but two timers with the same
- * name can not exist simultaneously - the first timer with the shared name must
+ * Tool to simplify manually collecting timing information. Timers with different names can be interleaved or nested,
+ * but two timers with the same name can not exist simultaneously - the first timer with the shared name must
  * be stopped before the second is started.
- * 
- * <pre>
- * {@code
+ * <pre>{@code
  * for (int i=0; i<N; i++) {
  *   Timing.startTimer("foo");
  *   ...code for which we are collecting timing information...
  *   Timing.stopTimer("foo");
  * }
- * }
- * </pre>
+ * }</pre>
  */
 public class Timing {
 
@@ -99,12 +95,12 @@ public class Timing {
 	}
 
 	/**
-	 * Returns the accumulated timing statistics for the timer with the
-	 * specified name; or {@code null} if no such timer exists.
+	 * Returns the accumulated timing statistics for the timer with the specified name; or {@code null} if no such
+	 * timer exists.
 	 * 
 	 * @param name the name of the timer
-	 * @return the accumulated timing statistics for the timer with the
-	 *         specified name; or {@code null} if no such timer exists
+	 * @return the accumulated timing statistics for the timer with the specified name; or {@code null} if no such
+	 *         timer exists
 	 */
 	public static SummaryStatistics getStatistics(String name) {
 		return data.get(name);
@@ -138,16 +134,14 @@ public class Timing {
 	}
 	
 	/**
-	 * Prints the relative magnitudes of the collected timer data to the
-	 * standard output stream.
+	 * Prints the relative magnitudes of the collected timer data to the standard output stream.
 	 */
 	public static void printMagnitudes() {
 		printMagnitudes(System.out);
 	}
 	
 	/**
-	 * Prints the relative magnitudes of the collected timer data to the
-	 * specified {@link PrintStream}.
+	 * Prints the relative magnitudes of the collected timer data to the specified {@link PrintStream}.
 	 * 
 	 * @param out the stream to which data is printed
 	 */

--- a/src/org/moeaframework/util/TypedProperties.java
+++ b/src/org/moeaframework/util/TypedProperties.java
@@ -1380,5 +1380,16 @@ public class TypedProperties implements Displayable {
 			throw new ConfigurationException("properties not accessed: " + String.join(", ", orphanedProperties));
 		}
 	}
+	
+	/**
+	 * Creates a new scope that allows making temporary changes to the properties.  When the scope is closed,
+	 * the original properties are restored.  Typically, you should create scopes within try-with-resources
+	 * blocks so they are automatically closed.
+	 * 
+	 * @return the scope
+	 */
+	public PropertyScope createScope() {
+		return new PropertyScope(this);
+	}
 
 }

--- a/src/org/moeaframework/util/TypedProperties.java
+++ b/src/org/moeaframework/util/TypedProperties.java
@@ -1301,6 +1301,7 @@ public class TypedProperties implements Displayable {
 	/**
 	 * Prints the properties to standard output.
 	 */
+	@Override
 	public void display(PrintStream out) {
 		try (StringWriter stringBuffer = new StringWriter()) {
 			store(stringBuffer);

--- a/src/org/moeaframework/util/io/UpdateCodeSamples.java
+++ b/src/org/moeaframework/util/io/UpdateCodeSamples.java
@@ -66,7 +66,7 @@ import org.moeaframework.util.CommandLineUtility;
  *   <li>{@code [<startingLine>:<endingLine>]} specifies the line numbers, starting at index 1, to extract from the
  *       file.  If no line numbers are provided, the entire content is copied.
  *   <li>{@code {<flag>,...}} specifies additional formatting options, such as {@code {keepComments}}.
- * <ul>
+ * </ul>
  * This utility can be run in validate-only mode or update mode.  In validate mode, any changes to the files will
  * result in an error.  This is useful in CI to validate the docs are up-to-date.  In update mode, the files are
  * updated with any changes.

--- a/test/org/moeaframework/analysis/sensitivity/ExtractDataTest.java
+++ b/test/org/moeaframework/analysis/sensitivity/ExtractDataTest.java
@@ -27,7 +27,8 @@ import org.moeaframework.TestUtils;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.indicator.Contribution;
-import org.moeaframework.core.indicator.QualityIndicator;
+import org.moeaframework.core.indicator.Indicators;
+import org.moeaframework.core.indicator.Indicators.IndicatorValues;
 import org.moeaframework.core.spi.ProblemFactory;
 import org.moeaframework.core.spi.ProblemFactoryTestWrapper;
 
@@ -116,33 +117,31 @@ public class ExtractDataTest {
 			"--output", output.getPath(),
 			"+ge", "+hyp", "+inv", "+err", "+spa", "+eps" });
 		
-		QualityIndicator indicator = new QualityIndicator(problem, 
-				referenceSet);
+		Indicators indicators = Indicators.of(problem, referenceSet);
 		
 		try (BufferedReader reader = new BufferedReader(new FileReader(output));
 			 ResultFileReader resultReader = new ResultFileReader(problem, input)) {
 			Assert.assertEquals("#+ge +hyp +inv +err +spa +eps", 
 					reader.readLine());
 				
-			NondominatedPopulation population = 
-					resultReader.next().getPopulation();
-			indicator.calculate(population);
-			Assert.assertEquals(indicator.getGenerationalDistance() + " " + 
-					indicator.getHypervolume() + " " +
-					indicator.getInvertedGenerationalDistance() + " " +
-					indicator.getMaximumParetoFrontError() + " " + 
-					indicator.getSpacing() + " " + 
-					indicator.getAdditiveEpsilonIndicator(), 
+			NondominatedPopulation population = resultReader.next().getPopulation();
+			IndicatorValues values = indicators.apply(population);
+			Assert.assertEquals(values.getGenerationalDistance() + " " + 
+					values.getHypervolume() + " " +
+					values.getInvertedGenerationalDistance() + " " +
+					values.getMaximumParetoFrontError() + " " + 
+					values.getSpacing() + " " + 
+					values.getAdditiveEpsilonIndicator(), 
 					reader.readLine());
 				
 			population = resultReader.next().getPopulation();
-			indicator.calculate(population);
-			Assert.assertEquals(indicator.getGenerationalDistance() + " " + 
-					indicator.getHypervolume() + " " +
-					indicator.getInvertedGenerationalDistance() + " " +
-					indicator.getMaximumParetoFrontError() + " " + 
-					indicator.getSpacing() + " " + 
-					indicator.getAdditiveEpsilonIndicator(), 
+			values = indicators.apply(population);
+			Assert.assertEquals(values.getGenerationalDistance() + " " + 
+					values.getHypervolume() + " " +
+					values.getInvertedGenerationalDistance() + " " +
+					values.getMaximumParetoFrontError() + " " + 
+					values.getSpacing() + " " + 
+					values.getAdditiveEpsilonIndicator(), 
 					reader.readLine());
 				
 			Assert.assertNull(reader.readLine());

--- a/test/org/moeaframework/analysis/sensitivity/ExtractDataTest.java
+++ b/test/org/moeaframework/analysis/sensitivity/ExtractDataTest.java
@@ -117,7 +117,7 @@ public class ExtractDataTest {
 			"--output", output.getPath(),
 			"+ge", "+hyp", "+inv", "+err", "+spa", "+eps" });
 		
-		Indicators indicators = Indicators.of(problem, referenceSet);
+		Indicators indicators = Indicators.standard(problem, referenceSet);
 		
 		try (BufferedReader reader = new BufferedReader(new FileReader(output));
 			 ResultFileReader resultReader = new ResultFileReader(problem, input)) {
@@ -163,13 +163,13 @@ public class ExtractDataTest {
 			"--input", input.getPath(),
 			"--output", output.getPath(),
 			"--epsilon", Double.toString(epsilon),
-			"+con" });
+			"+contribution" });
 
 		Contribution contribution = new Contribution(referenceSet, epsilon);
 		
 		try (BufferedReader reader = new BufferedReader(new FileReader(output));
 				ResultFileReader resultReader = new ResultFileReader(problem, input)) {
-			Assert.assertEquals("#+con", reader.readLine());
+			Assert.assertEquals("#+contribution", reader.readLine());
 				
 			NondominatedPopulation population = 
 					resultReader.next().getPopulation();
@@ -197,13 +197,13 @@ public class ExtractDataTest {
 			"--reference", new File("./pf/DTLZ2.2D.pf").getAbsolutePath(),
 			"--input", input.getPath(),
 			"--output", output.getPath(),
-			"+con" });
+			"+contribution" });
 		
 		Contribution contribution = new Contribution(referenceSet);
 		
 		try (BufferedReader reader = new BufferedReader(new FileReader(output));
 			 ResultFileReader resultReader = new ResultFileReader(problem, input)) {
-			Assert.assertEquals("#+con", reader.readLine());
+			Assert.assertEquals("#+contribution", reader.readLine());
 				
 			NondominatedPopulation population = 
 					resultReader.next().getPopulation();

--- a/test/org/moeaframework/analysis/sensitivity/FeasibilityRatioTest.java
+++ b/test/org/moeaframework/analysis/sensitivity/FeasibilityRatioTest.java
@@ -19,7 +19,6 @@ package org.moeaframework.analysis.sensitivity;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.moeaframework.core.PRNG;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
@@ -77,14 +76,14 @@ public class FeasibilityRatioTest {
 	}
 	
 	@Test
-	public void testRandomlyFeasibleSolutions() {
-		double percentFeasible = 0.25;
-		
+	public void testPercentFeasibleSolutions() {
 		Problem problem = new AbstractProblem(1, 1, 1) {
+			
+			private int count = 0;
 
 			@Override
 			public void evaluate(Solution solution) {
-				solution.setConstraint(0, PRNG.nextDouble() < percentFeasible ? 0.0 : -1.0);
+				solution.setConstraint(0, (count++) % 4 == 0 ? 0.0 : -1.0);
 			}
 
 			@Override
@@ -96,7 +95,7 @@ public class FeasibilityRatioTest {
 			
 		};
 		
-		Assert.assertEquals(percentFeasible, FeasibilityRatio.calculate(problem, 10000), 0.01);
+		Assert.assertEquals(0.25, FeasibilityRatio.calculate(problem, 100), 0.01);
 	}
 
 }

--- a/test/org/moeaframework/analysis/sensitivity/MetricFileWriterTest.java
+++ b/test/org/moeaframework/analysis/sensitivity/MetricFileWriterTest.java
@@ -28,7 +28,7 @@ import org.moeaframework.analysis.sensitivity.MetricFileWriter.MetricFileWriterS
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Solution;
-import org.moeaframework.core.indicator.QualityIndicator;
+import org.moeaframework.core.indicator.Indicators;
 import org.moeaframework.core.spi.ProblemFactory;
 
 /**
@@ -45,16 +45,14 @@ public class MetricFileWriterTest {
 	public void test() throws IOException {
 		File file = TestUtils.createTempFile();
 		Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");
-		NondominatedPopulation referenceSet = ProblemFactory.getInstance()
-				.getReferenceSet("DTLZ2_2");
-		QualityIndicator qualityIndicator = new QualityIndicator(problem,
-				referenceSet);
+		NondominatedPopulation referenceSet = ProblemFactory.getInstance().getReferenceSet("DTLZ2_2");
+		Indicators indicators = Indicators.standard(problem, referenceSet);
 
 		NondominatedPopulation approximationSet = new NondominatedPopulation();
 		approximationSet.add(new Solution(new double[] { 0.0, 1.0 }));
 		approximationSet.add(new Solution(new double[] { 1.0, 0.0 }));
 
-		try (MetricFileWriter writer = new MetricFileWriter(qualityIndicator, file)) {
+		try (MetricFileWriter writer = new MetricFileWriter(indicators, file)) {
 			Assert.assertEquals(0, writer.getNumberOfEntries());
 
 			writer.append(new ResultEntry(approximationSet));
@@ -63,7 +61,7 @@ public class MetricFileWriterTest {
 			Assert.assertEquals(2, writer.getNumberOfEntries());
 		}
 
-		try (MetricFileWriter writer = new MetricFileWriter(qualityIndicator, file)) {
+		try (MetricFileWriter writer = new MetricFileWriter(indicators, file)) {
 			Assert.assertEquals(2, writer.getNumberOfEntries());
 
 			writer.append(new ResultEntry(approximationSet));

--- a/test/org/moeaframework/core/SettingsTest.java
+++ b/test/org/moeaframework/core/SettingsTest.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.moeaframework.TestUtils;
 import org.moeaframework.core.NondominatedPopulation.DuplicateMode;
+import org.moeaframework.core.Settings.Scope;
 
 /**
  * Tests the {@link Settings} class.  These tests ensure that valid settings
@@ -66,24 +67,20 @@ public class SettingsTest {
 	
 	@Test
 	public void testDiagnosticToolAlgorithmsOverride() {
-		Settings.PROPERTIES.setStringArray(Settings.KEY_DIAGNOSTIC_TOOL_ALGORITHMS, new String[] { "foo" });
-		
-		List<String> result = Arrays.asList(Settings.getDiagnosticToolAlgorithms());
-		Assert.assertTrue(result.size() == 1);
-		Assert.assertTrue(result.contains("foo"));
-		
-		Settings.PROPERTIES.remove(Settings.KEY_DIAGNOSTIC_TOOL_ALGORITHMS);
+		try (Scope scope = Settings.createScope().with(Settings.KEY_DIAGNOSTIC_TOOL_ALGORITHMS, "foo")) {
+			List<String> result = Arrays.asList(Settings.getDiagnosticToolAlgorithms());
+			Assert.assertTrue(result.size() == 1);
+			Assert.assertTrue(result.contains("foo"));
+		}
 	}
 	
 	@Test
 	public void testDiagnosticToolProblemsOverride() {
-		Settings.PROPERTIES.setStringArray(Settings.KEY_DIAGNOSTIC_TOOL_PROBLEMS, new String[] { "bar" });
-		
-		List<String> result = Arrays.asList(Settings.getDiagnosticToolProblems());
-		Assert.assertTrue(result.size() == 1);
-		Assert.assertTrue(result.contains("bar"));
-		
-		Settings.PROPERTIES.remove(Settings.KEY_DIAGNOSTIC_TOOL_PROBLEMS);
+		try (Scope scope = Settings.createScope().with(Settings.KEY_DIAGNOSTIC_TOOL_PROBLEMS, "bar")) {
+			List<String> result = Arrays.asList(Settings.getDiagnosticToolProblems());
+			Assert.assertTrue(result.size() == 1);
+			Assert.assertTrue(result.contains("bar"));
+		}
 	}
 	
 	@Test
@@ -93,13 +90,11 @@ public class SettingsTest {
 	
 	@Test
 	public void testDuplicateModeCaseSensitivity() {
-		Settings.PROPERTIES.setString(Settings.KEY_DUPLICATE_MODE, DuplicateMode.ALLOW_DUPLICATES.name().toLowerCase());
-		
-		Assert.assertEquals(DuplicateMode.ALLOW_DUPLICATES, Settings.getDuplicateMode());
-		
-		Assert.assertEquals(DuplicateMode.ALLOW_DUPLICATES, new NondominatedPopulation().duplicateMode);
-		
-		Settings.PROPERTIES.remove(Settings.KEY_DUPLICATE_MODE);
+		try (Scope scope = Settings.createScope()
+				.with(Settings.KEY_DUPLICATE_MODE, DuplicateMode.ALLOW_DUPLICATES.name().toLowerCase())) {
+			Assert.assertEquals(DuplicateMode.ALLOW_DUPLICATES, Settings.getDuplicateMode());
+			Assert.assertEquals(DuplicateMode.ALLOW_DUPLICATES, new NondominatedPopulation().duplicateMode);
+		}
 	}
 	
 	@Test
@@ -146,6 +141,51 @@ public class SettingsTest {
 		Settings.reload();
 		
 		Assert.assertTrue(Settings.PROPERTIES.contains("org.moeaframework.test.test_property_in_file"));		
+	}
+	
+	@Test
+	public void testScopeOnUndefinedSetting() {
+		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
+		
+		try (Scope scope = Settings.createScope().with("foo", "bar")) {
+			Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
+			Assert.assertEquals("bar", Settings.PROPERTIES.getString("foo"));
+		}
+		
+		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
+	}
+	
+	@Test
+	public void testScopeOnOverriddenSetting() {
+		Settings.PROPERTIES.setString("foo", "bar");
+		
+		Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
+		Assert.assertEquals("bar", Settings.PROPERTIES.getString("foo"));
+		
+		try (Scope scope = Settings.createScope().with("foo", "baz")) {
+			Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
+			Assert.assertEquals("baz", Settings.PROPERTIES.getString("foo"));
+		}
+		
+		Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
+		Assert.assertEquals("bar", Settings.PROPERTIES.getString("foo"));
+	}
+	
+	@Test
+	public void testScopeWithSetSetting() {
+		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
+		Assert.assertFalse(Settings.PROPERTIES.contains("hello"));
+		
+		try (Scope scope = Settings.createScope().with("foo", "bar")) {
+			Settings.PROPERTIES.setString("foo", "baz");     // Removed when existing scope
+			Settings.PROPERTIES.setString("hello", "world"); // Kept because not captured by scope
+			
+			Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
+			Assert.assertEquals("baz", Settings.PROPERTIES.getString("foo"));
+		}
+		
+		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
+		Assert.assertTrue(Settings.PROPERTIES.contains("hello"));
 	}
 
 }

--- a/test/org/moeaframework/core/SettingsTest.java
+++ b/test/org/moeaframework/core/SettingsTest.java
@@ -26,7 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.moeaframework.TestUtils;
 import org.moeaframework.core.NondominatedPopulation.DuplicateMode;
-import org.moeaframework.core.Settings.Scope;
+import org.moeaframework.util.PropertyScope;
 
 /**
  * Tests the {@link Settings} class.  These tests ensure that valid settings
@@ -67,7 +67,7 @@ public class SettingsTest {
 	
 	@Test
 	public void testDiagnosticToolAlgorithmsOverride() {
-		try (Scope scope = Settings.createScope().with(Settings.KEY_DIAGNOSTIC_TOOL_ALGORITHMS, "foo")) {
+		try (PropertyScope scope = Settings.createScope().with(Settings.KEY_DIAGNOSTIC_TOOL_ALGORITHMS, "foo")) {
 			List<String> result = Arrays.asList(Settings.getDiagnosticToolAlgorithms());
 			Assert.assertTrue(result.size() == 1);
 			Assert.assertTrue(result.contains("foo"));
@@ -76,7 +76,7 @@ public class SettingsTest {
 	
 	@Test
 	public void testDiagnosticToolProblemsOverride() {
-		try (Scope scope = Settings.createScope().with(Settings.KEY_DIAGNOSTIC_TOOL_PROBLEMS, "bar")) {
+		try (PropertyScope scope = Settings.createScope().with(Settings.KEY_DIAGNOSTIC_TOOL_PROBLEMS, "bar")) {
 			List<String> result = Arrays.asList(Settings.getDiagnosticToolProblems());
 			Assert.assertTrue(result.size() == 1);
 			Assert.assertTrue(result.contains("bar"));
@@ -90,7 +90,7 @@ public class SettingsTest {
 	
 	@Test
 	public void testDuplicateModeCaseSensitivity() {
-		try (Scope scope = Settings.createScope()
+		try (PropertyScope scope = Settings.createScope()
 				.with(Settings.KEY_DUPLICATE_MODE, DuplicateMode.ALLOW_DUPLICATES.name().toLowerCase())) {
 			Assert.assertEquals(DuplicateMode.ALLOW_DUPLICATES, Settings.getDuplicateMode());
 			Assert.assertEquals(DuplicateMode.ALLOW_DUPLICATES, new NondominatedPopulation().duplicateMode);
@@ -144,48 +144,18 @@ public class SettingsTest {
 	}
 	
 	@Test
-	public void testScopeOnUndefinedSetting() {
+	public void testScope() {
 		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
 		
-		try (Scope scope = Settings.createScope().with("foo", "bar")) {
+		try (PropertyScope scope = Settings.createScope().with("foo", "bar")) {
 			Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
-			Assert.assertEquals("bar", Settings.PROPERTIES.getString("foo"));
-		}
-		
-		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
-	}
-	
-	@Test
-	public void testScopeOnOverriddenSetting() {
-		Settings.PROPERTIES.setString("foo", "bar");
-		
-		Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
-		Assert.assertEquals("bar", Settings.PROPERTIES.getString("foo"));
-		
-		try (Scope scope = Settings.createScope().with("foo", "baz")) {
-			Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
-			Assert.assertEquals("baz", Settings.PROPERTIES.getString("foo"));
-		}
-		
-		Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
-		Assert.assertEquals("bar", Settings.PROPERTIES.getString("foo"));
-	}
-	
-	@Test
-	public void testScopeWithSetSetting() {
-		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
-		Assert.assertFalse(Settings.PROPERTIES.contains("hello"));
-		
-		try (Scope scope = Settings.createScope().with("foo", "bar")) {
-			Settings.PROPERTIES.setString("foo", "baz");     // Removed when existing scope
-			Settings.PROPERTIES.setString("hello", "world"); // Kept because not captured by scope
 			
-			Assert.assertTrue(Settings.PROPERTIES.contains("foo"));
-			Assert.assertEquals("baz", Settings.PROPERTIES.getString("foo"));
+			Settings.PROPERTIES.setInt("number", 5);
+			Assert.assertEquals(5, Settings.PROPERTIES.getInt("number"));
 		}
 		
 		Assert.assertFalse(Settings.PROPERTIES.contains("foo"));
-		Assert.assertTrue(Settings.PROPERTIES.contains("hello"));
+		Assert.assertFalse(Settings.PROPERTIES.contains("number"));
 	}
 
 }

--- a/test/org/moeaframework/core/indicator/IndicatorsTest.java
+++ b/test/org/moeaframework/core/indicator/IndicatorsTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
-import org.moeaframework.core.Settings.Scope;
 import org.moeaframework.core.indicator.Indicators.IndicatorValues;
 import org.moeaframework.core.spi.ProblemFactory;
+import org.moeaframework.util.PropertyScope;
 
 public class IndicatorsTest {
 	
@@ -41,7 +41,7 @@ public class IndicatorsTest {
 		Problem problem = problemFactory.getProblem(problemName);
 		NondominatedPopulation referenceSet = problemFactory.getReferenceSet(problemName);
 		
-		indicators = Indicators.from(problem, referenceSet);
+		indicators = Indicators.of(problem, referenceSet);
 		testApproximationSet = referenceSet;
 	}
 	
@@ -122,7 +122,7 @@ public class IndicatorsTest {
 	
 	@Test
 	public void testDisabledHypervolume() {
-		try (Scope scope = Settings.createScope().with(Settings.KEY_HYPERVOLUME_ENABLED, false)) {
+		try (PropertyScope scope = Settings.createScope().with(Settings.KEY_HYPERVOLUME_ENABLED, false)) {
 			indicators.includeStandardMetrics();
 			IndicatorValues values = indicators.apply(testApproximationSet);
 			Assert.assertTrue(Double.isNaN(values.getHypervolume()));

--- a/test/org/moeaframework/core/indicator/IndicatorsTest.java
+++ b/test/org/moeaframework/core/indicator/IndicatorsTest.java
@@ -1,0 +1,141 @@
+/* Copyright 2009-2024 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.core.indicator;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.moeaframework.core.NondominatedPopulation;
+import org.moeaframework.core.Problem;
+import org.moeaframework.core.Settings;
+import org.moeaframework.core.Settings.Scope;
+import org.moeaframework.core.indicator.Indicators.IndicatorValues;
+import org.moeaframework.core.spi.ProblemFactory;
+
+public class IndicatorsTest {
+	
+	private Indicators indicators;
+	
+	private NondominatedPopulation testApproximationSet;
+	
+	@Before
+	public void setUp() {
+		String problemName = "DTLZ2_2";
+		ProblemFactory problemFactory = ProblemFactory.getInstance();
+		Problem problem = problemFactory.getProblem(problemName);
+		NondominatedPopulation referenceSet = problemFactory.getReferenceSet(problemName);
+		
+		indicators = Indicators.from(problem, referenceSet);
+		testApproximationSet = referenceSet;
+	}
+	
+	@After
+	public void tearDown() {
+		indicators = null;
+	}
+
+	@Test
+	public void testNoneEnabled() {
+		IndicatorValues values = indicators.apply(testApproximationSet);
+		
+		Assert.assertTrue(Double.isNaN(values.getHypervolume()));
+		Assert.assertTrue(Double.isNaN(values.getGenerationalDistance()));
+		Assert.assertTrue(Double.isNaN(values.getInvertedGenerationalDistance()));
+		Assert.assertTrue(Double.isNaN(values.getAdditiveEpsilonIndicator()));
+		Assert.assertTrue(Double.isNaN(values.getSpacing()));
+		Assert.assertTrue(Double.isNaN(values.getMaximumParetoFrontError()));
+		Assert.assertTrue(Double.isNaN(values.getContribution()));
+		Assert.assertTrue(Double.isNaN(values.getR1()));
+		Assert.assertTrue(Double.isNaN(values.getR2()));
+		Assert.assertTrue(Double.isNaN(values.getR3()));
+		
+		Assert.assertEquals(0, values.asProperties().size());
+	}
+	
+	@Test
+	public void testStandardMetrics() {
+		indicators.includeStandardMetrics();
+		
+		IndicatorValues values = indicators.apply(testApproximationSet);
+		
+		Assert.assertFalse(Double.isNaN(values.getHypervolume()));
+		Assert.assertFalse(Double.isNaN(values.getGenerationalDistance()));
+		Assert.assertFalse(Double.isNaN(values.getInvertedGenerationalDistance()));
+		Assert.assertFalse(Double.isNaN(values.getAdditiveEpsilonIndicator()));
+		Assert.assertFalse(Double.isNaN(values.getSpacing()));
+		Assert.assertFalse(Double.isNaN(values.getMaximumParetoFrontError()));
+		Assert.assertFalse(Double.isNaN(values.getContribution()));
+		Assert.assertTrue(Double.isNaN(values.getR1()));
+		Assert.assertTrue(Double.isNaN(values.getR2()));
+		Assert.assertTrue(Double.isNaN(values.getR3()));
+		
+		Assert.assertEquals(7, values.asProperties().size());
+	}
+	
+	@Test
+	public void testAllMetrics() {
+		indicators.includeAllMetrics();
+		
+		IndicatorValues values = indicators.apply(testApproximationSet);
+		
+		Assert.assertFalse(Double.isNaN(values.getHypervolume()));
+		Assert.assertFalse(Double.isNaN(values.getGenerationalDistance()));
+		Assert.assertFalse(Double.isNaN(values.getInvertedGenerationalDistance()));
+		Assert.assertFalse(Double.isNaN(values.getAdditiveEpsilonIndicator()));
+		Assert.assertFalse(Double.isNaN(values.getSpacing()));
+		Assert.assertFalse(Double.isNaN(values.getMaximumParetoFrontError()));
+		Assert.assertFalse(Double.isNaN(values.getContribution()));
+		Assert.assertFalse(Double.isNaN(values.getR1()));
+		Assert.assertFalse(Double.isNaN(values.getR2()));
+		Assert.assertFalse(Double.isNaN(values.getR3()));
+		
+		Assert.assertEquals(10, values.asProperties().size());
+	}
+	
+	@Test
+	public void testUpdates() {
+		IndicatorValues values = indicators.apply(testApproximationSet);
+		Assert.assertTrue(Double.isNaN(values.getHypervolume()));
+		Assert.assertEquals(0, values.asProperties().size());
+		
+		indicators.includeHypervolume();
+		values = indicators.apply(testApproximationSet);
+		Assert.assertFalse(Double.isNaN(values.getHypervolume()));
+		Assert.assertEquals(1, values.asProperties().size());
+	}
+	
+	@Test
+	public void testDisabledHypervolume() {
+		try (Scope scope = Settings.createScope().with(Settings.KEY_HYPERVOLUME_ENABLED, false)) {
+			indicators.includeStandardMetrics();
+			IndicatorValues values = indicators.apply(testApproximationSet);
+			Assert.assertTrue(Double.isNaN(values.getHypervolume()));
+			
+			indicators.includeAllMetrics();
+			values = indicators.apply(testApproximationSet);
+			Assert.assertTrue(Double.isNaN(values.getHypervolume()));
+			
+			// including hypervolume directly ignores the setting
+			indicators.includeHypervolume();
+			values = indicators.apply(testApproximationSet);
+			Assert.assertFalse(Double.isNaN(values.getHypervolume()));
+		}
+	}
+
+}

--- a/test/org/moeaframework/core/indicator/NativeHypervolumeTest.java
+++ b/test/org/moeaframework/core/indicator/NativeHypervolumeTest.java
@@ -54,9 +54,7 @@ public class NativeHypervolumeTest {
 	
 	@Test
 	public void testInvokeNativeProcess() throws IOException {
-		double value = NativeHypervolume.invokeNativeProcess(SystemUtils.IS_OS_WINDOWS ?
-				"cmd /C \"echo hypervolume is 0.75\"" : "echo \"hypervolume is 0.75\"");
-		
+		double value = NativeHypervolume.invokeNativeProcess(getCommand());
 		Assert.assertEquals(0.75, value, Settings.EPS);
 	}
 	
@@ -69,11 +67,17 @@ public class NativeHypervolumeTest {
 	
 	@Test
 	public void testEvaluate() {
-		try (PropertyScope scope = Settings.createScope().with(Settings.KEY_HYPERVOLUME,
-				SystemUtils.IS_OS_WINDOWS ? "cmd /C \"echo {0} {1} {2} {3} {4} 0.75\"" : "echo \"{0} {1} {2} {3} {4} 0.75\"")) {
+		try (PropertyScope scope = Settings.createScope().with(Settings.KEY_HYPERVOLUME, getCommand())) {
 			double value = NativeHypervolume.evaluate(new MockRealProblem(2), new NondominatedPopulation());
 			Assert.assertEquals(0.75, value, Settings.EPS);
 		}
+	}
+	
+	// Mimic native hypervolume executable.  The last item on the last line is read as the hypervolume value.
+	private String getCommand() {
+		return SystemUtils.IS_OS_WINDOWS ?
+				"cmd /C \"echo {0} {1} {2} {3} {4} 0.75\"" :
+				"echo \"{0} {1} {2} {3} {4} 0.75\"";
 	}
 
 }

--- a/test/org/moeaframework/core/indicator/NativeHypervolumeTest.java
+++ b/test/org/moeaframework/core/indicator/NativeHypervolumeTest.java
@@ -1,3 +1,20 @@
+/* Copyright 2009-2024 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.moeaframework.core.indicator;
 
 import java.io.IOException;

--- a/test/org/moeaframework/core/indicator/PISAHypervolumeTest.java
+++ b/test/org/moeaframework/core/indicator/PISAHypervolumeTest.java
@@ -24,8 +24,8 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
-import org.moeaframework.core.Settings.Scope;
 import org.moeaframework.core.spi.ProblemFactory;
+import org.moeaframework.util.PropertyScope;
 
 /**
  * Tests the {@link PISAHypervolume} class. Due to performance, these tests only go up to 4 dimensions.
@@ -183,7 +183,7 @@ public class PISAHypervolumeTest extends IndicatorTest {
 	
 	@Test
 	public void testExplicitBounds2_Properties() {
-		try (Scope scope = Settings.createScope()
+		try (PropertyScope scope = Settings.createScope()
 				.with("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2", 0.0)
 				.with("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2", 2.0)) {
 			Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");

--- a/test/org/moeaframework/core/indicator/PISAHypervolumeTest.java
+++ b/test/org/moeaframework/core/indicator/PISAHypervolumeTest.java
@@ -24,6 +24,7 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.Settings.Scope;
 import org.moeaframework.core.spi.ProblemFactory;
 
 /**
@@ -182,17 +183,13 @@ public class PISAHypervolumeTest extends IndicatorTest {
 	
 	@Test
 	public void testExplicitBounds2_Properties() {
-		Settings.PROPERTIES.setDouble("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2", 0.0);
-		Settings.PROPERTIES.setDouble("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2", 2.0);
-		
-		Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");
-		
-		PISAHypervolume hypervolume = new PISAHypervolume(problem, new NondominatedPopulation());
-		
-		test2(hypervolume);
-		
-		Settings.PROPERTIES.remove("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2");
-		Settings.PROPERTIES.remove("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2");
+		try (Scope scope = Settings.createScope()
+				.with("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2", 0.0)
+				.with("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2", 2.0)) {
+			Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");
+			PISAHypervolume hypervolume = new PISAHypervolume(problem, new NondominatedPopulation());
+			test2(hypervolume);
+		}
 	}
 
 }

--- a/test/org/moeaframework/core/indicator/QualityIndicatorTest.java
+++ b/test/org/moeaframework/core/indicator/QualityIndicatorTest.java
@@ -27,6 +27,7 @@ import org.moeaframework.core.spi.ProblemFactory;
 /**
  * Tests the {@link QualityIndicator} class.
  */
+@Deprecated
 public class QualityIndicatorTest {
 	
 	private QualityIndicator qualityIndicator;

--- a/test/org/moeaframework/core/indicator/WFGNormalizedHypervolumeTest.java
+++ b/test/org/moeaframework/core/indicator/WFGNormalizedHypervolumeTest.java
@@ -24,6 +24,7 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
+import org.moeaframework.core.Settings.Scope;
 import org.moeaframework.core.spi.ProblemFactory;
 
 /**
@@ -182,17 +183,13 @@ public class WFGNormalizedHypervolumeTest extends IndicatorTest {
 	
 	@Test
 	public void testExplicitBounds2_Properties() {
-		Settings.PROPERTIES.setDouble("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2", 0.0);
-		Settings.PROPERTIES.setDouble("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2", 2.0);
-		
-		Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");
-		
-		WFGNormalizedHypervolume hypervolume = new WFGNormalizedHypervolume(problem, new NondominatedPopulation());
-		
-		test2(hypervolume);
-		
-		Settings.PROPERTIES.remove("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2");
-		Settings.PROPERTIES.remove("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2");
+		try (Scope scope = Settings.createScope()
+				.with("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2", 0.0)
+				.with("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2", 2.0)) {
+			Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");
+			WFGNormalizedHypervolume hypervolume = new WFGNormalizedHypervolume(problem, new NondominatedPopulation());
+			test2(hypervolume);
+		}
 	}
 	
 	@Test

--- a/test/org/moeaframework/core/indicator/WFGNormalizedHypervolumeTest.java
+++ b/test/org/moeaframework/core/indicator/WFGNormalizedHypervolumeTest.java
@@ -24,8 +24,8 @@ import org.moeaframework.core.NondominatedPopulation;
 import org.moeaframework.core.Problem;
 import org.moeaframework.core.Settings;
 import org.moeaframework.core.Solution;
-import org.moeaframework.core.Settings.Scope;
 import org.moeaframework.core.spi.ProblemFactory;
+import org.moeaframework.util.PropertyScope;
 
 /**
  * Tests the {@link WFGNormalizedHypervolume} class.
@@ -183,7 +183,7 @@ public class WFGNormalizedHypervolumeTest extends IndicatorTest {
 	
 	@Test
 	public void testExplicitBounds2_Properties() {
-		try (Scope scope = Settings.createScope()
+		try (PropertyScope scope = Settings.createScope()
 				.with("org.moeaframework.core.indicator.hypervolume_idealpt.DTLZ2", 0.0)
 				.with("org.moeaframework.core.indicator.hypervolume_refpt.DTLZ2", 2.0)) {
 			Problem problem = ProblemFactory.getInstance().getProblem("DTLZ2_2");

--- a/test/org/moeaframework/problem/PropertiesProblemsTest.java
+++ b/test/org/moeaframework/problem/PropertiesProblemsTest.java
@@ -20,66 +20,48 @@ package org.moeaframework.problem;
 import org.junit.Assert;
 import org.junit.Test;
 import org.moeaframework.core.Settings;
+import org.moeaframework.core.Settings.Scope;
 import org.moeaframework.core.spi.ProblemFactory;
 import org.moeaframework.core.spi.ProviderNotFoundException;
 
-/**
- * Tests the {@link PropertiesProblems} class.
- */
 public class PropertiesProblemsTest {
 	
 	@Test
 	public void testWithoutReferenceSet() {
-		Settings.PROPERTIES.setString(
-				"org.moeaframework.problem.TestWithoutReferenceSet.class", 
-				"org.moeaframework.problem.ZDT.ZDT1");
-		
-		Assert.assertNotNull(ProblemFactory.getInstance().getProblem(
-				"TestWithoutReferenceSet"));
-		Assert.assertNull(ProblemFactory.getInstance().getReferenceSet(
-				"TestWithoutReferenceSet"));
+		try (Scope scope = Settings.createScope()
+				.with("org.moeaframework.problem.TestWithoutReferenceSet.class", "org.moeaframework.problem.ZDT.ZDT1")) {
+			Assert.assertNotNull(ProblemFactory.getInstance().getProblem("TestWithoutReferenceSet"));
+			Assert.assertNull(ProblemFactory.getInstance().getReferenceSet("TestWithoutReferenceSet"));
+		}
 	}
 	
 	@Test
 	public void testWithReferenceSet() {
-		Settings.PROPERTIES.setString(
-				"org.moeaframework.problem.TestWithReferenceSet.class", 
-				"org.moeaframework.problem.ZDT.ZDT1");
-		Settings.PROPERTIES.setString(
-				"org.moeaframework.problem.TestWithReferenceSet.referenceSet", 
-				"./pf/ZDT1.pf");
-		
-		Assert.assertNotNull(ProblemFactory.getInstance().getProblem(
-				"TestWithReferenceSet"));
-		Assert.assertNotNull(ProblemFactory.getInstance().getReferenceSet(
-				"TestWithReferenceSet"));
+		try (Scope scope = Settings.createScope()
+				.with("org.moeaframework.problem.TestWithReferenceSet.class", "org.moeaframework.problem.ZDT.ZDT1")
+				.with("org.moeaframework.problem.TestWithReferenceSet.referenceSet", "./pf/ZDT1.pf")) {
+			Assert.assertNotNull(ProblemFactory.getInstance().getProblem("TestWithReferenceSet"));
+			Assert.assertNotNull(ProblemFactory.getInstance().getReferenceSet("TestWithReferenceSet"));
+		}
 	}
 	
 	@Test(expected = ProviderNotFoundException.class)
 	public void testNoEmptyConstructor() {
-		Settings.PROPERTIES.setString(
-				"org.moeaframework.problem.TestNoEmptyConstructor.class", 
-				"org.moeaframework.problem.DTLZ.DTLZ2");
-		
-		ProblemFactory.getInstance().getProblem("TestNoEmptyConstructor");
+		try (Scope scope = Settings.createScope()
+				.with("org.moeaframework.problem.TestNoEmptyConstructor.class", "org.moeaframework.problem.DTLZ.DTLZ2")) {
+			ProblemFactory.getInstance().getProblem("TestNoEmptyConstructor");
+		}
 	}
 	
 	@Test
 	public void testCaseSensitivity() {
-		Settings.PROPERTIES.setString(
-				"org.moeaframework.problem.problems", 
-				"TestCaseSensitivity");
-		Settings.PROPERTIES.setString(
-				"org.moeaframework.problem.TestCaseSensitivity.class", 
-				"org.moeaframework.problem.ZDT.ZDT1");
-		Settings.PROPERTIES.setString(
-				"org.moeaframework.problem.TestCaseSensitivity.referenceSet", 
-				"./pf/ZDT1.pf");
-		
-		Assert.assertNotNull(ProblemFactory.getInstance().getProblem(
-				"testcasesensitivity"));
-		Assert.assertNotNull(ProblemFactory.getInstance().getReferenceSet(
-				"TESTCASESENSITIVITY"));
+		try (Scope scope = Settings.createScope()
+				.with("org.moeaframework.problem.problems", "TestCaseSensitivity")
+				.with("org.moeaframework.problem.TestCaseSensitivity.class", "org.moeaframework.problem.ZDT.ZDT1")
+				.with("org.moeaframework.problem.TestCaseSensitivity.referenceSet", "./pf/ZDT1.pf")) {
+			Assert.assertNotNull(ProblemFactory.getInstance().getProblem("testcasesensitivity"));
+			Assert.assertNotNull(ProblemFactory.getInstance().getReferenceSet("TESTCASESENSITIVITY"));
+		}
 	}
 
 }

--- a/test/org/moeaframework/problem/PropertiesProblemsTest.java
+++ b/test/org/moeaframework/problem/PropertiesProblemsTest.java
@@ -20,15 +20,15 @@ package org.moeaframework.problem;
 import org.junit.Assert;
 import org.junit.Test;
 import org.moeaframework.core.Settings;
-import org.moeaframework.core.Settings.Scope;
 import org.moeaframework.core.spi.ProblemFactory;
 import org.moeaframework.core.spi.ProviderNotFoundException;
+import org.moeaframework.util.PropertyScope;
 
 public class PropertiesProblemsTest {
 	
 	@Test
 	public void testWithoutReferenceSet() {
-		try (Scope scope = Settings.createScope()
+		try (PropertyScope scope = Settings.createScope()
 				.with("org.moeaframework.problem.TestWithoutReferenceSet.class", "org.moeaframework.problem.ZDT.ZDT1")) {
 			Assert.assertNotNull(ProblemFactory.getInstance().getProblem("TestWithoutReferenceSet"));
 			Assert.assertNull(ProblemFactory.getInstance().getReferenceSet("TestWithoutReferenceSet"));
@@ -37,7 +37,7 @@ public class PropertiesProblemsTest {
 	
 	@Test
 	public void testWithReferenceSet() {
-		try (Scope scope = Settings.createScope()
+		try (PropertyScope scope = Settings.createScope()
 				.with("org.moeaframework.problem.TestWithReferenceSet.class", "org.moeaframework.problem.ZDT.ZDT1")
 				.with("org.moeaframework.problem.TestWithReferenceSet.referenceSet", "./pf/ZDT1.pf")) {
 			Assert.assertNotNull(ProblemFactory.getInstance().getProblem("TestWithReferenceSet"));
@@ -47,7 +47,7 @@ public class PropertiesProblemsTest {
 	
 	@Test(expected = ProviderNotFoundException.class)
 	public void testNoEmptyConstructor() {
-		try (Scope scope = Settings.createScope()
+		try (PropertyScope scope = Settings.createScope()
 				.with("org.moeaframework.problem.TestNoEmptyConstructor.class", "org.moeaframework.problem.DTLZ.DTLZ2")) {
 			ProblemFactory.getInstance().getProblem("TestNoEmptyConstructor");
 		}
@@ -55,7 +55,7 @@ public class PropertiesProblemsTest {
 	
 	@Test
 	public void testCaseSensitivity() {
-		try (Scope scope = Settings.createScope()
+		try (PropertyScope scope = Settings.createScope()
 				.with("org.moeaframework.problem.problems", "TestCaseSensitivity")
 				.with("org.moeaframework.problem.TestCaseSensitivity.class", "org.moeaframework.problem.ZDT.ZDT1")
 				.with("org.moeaframework.problem.TestCaseSensitivity.referenceSet", "./pf/ZDT1.pf")) {

--- a/test/org/moeaframework/util/PropertyScopeTest.java
+++ b/test/org/moeaframework/util/PropertyScopeTest.java
@@ -1,0 +1,95 @@
+/* Copyright 2009-2024 David Hadka
+ *
+ * This file is part of the MOEA Framework.
+ *
+ * The MOEA Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * The MOEA Framework is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the MOEA Framework.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.moeaframework.util;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PropertyScopeTest {
+
+	private TypedProperties original;
+
+	@Before
+	public void setUp() {
+		original = new TypedProperties();
+		original.setString("foo", "bar");
+	}
+
+	@After
+	public void tearDown() {
+		original = null;
+	}
+	
+	private TypedProperties createTestProperties() {
+		TypedProperties properties = new TypedProperties();
+		properties.addAll(original);
+		return properties;
+	}
+	
+	private void assertOriginalProperties(TypedProperties properties) {
+		Assert.assertEquals(properties, original);
+	}
+	
+	@Test
+	public void testNoChanges() {
+		TypedProperties properties = createTestProperties();
+		
+		try (PropertyScope scope = properties.createScope()) {
+			// do nothing
+		}
+		
+		assertOriginalProperties(properties);
+	}
+	
+	@Test
+	public void testOverwriteValue() {
+		TypedProperties properties = createTestProperties();
+		Assert.assertEquals("bar", properties.getString("foo"));
+		
+		try (PropertyScope scope = properties.createScope().with("foo", "baz")) {
+			Assert.assertEquals("baz", properties.getString("foo"));
+		}
+		
+		assertOriginalProperties(properties);
+	}
+	
+	@Test
+	public void testNewValue() {
+		TypedProperties properties = createTestProperties();
+		
+		try (PropertyScope scope = properties.createScope().with("new", "value")) {
+			Assert.assertEquals("value", properties.getString("new"));
+		}
+		
+		assertOriginalProperties(properties);
+	}
+	
+	@Test
+	public void testRemoveValue() {
+		TypedProperties properties = createTestProperties();
+		
+		try (PropertyScope scope = properties.createScope().without("foo")) {
+			Assert.assertFalse(properties.contains("foo"));
+		}
+		
+		assertOriginalProperties(properties);
+	}
+
+}

--- a/website/xslt/examples.xml
+++ b/website/xslt/examples.xml
@@ -224,8 +224,8 @@ R3                           0.000389
 <pre class="brush: java; toolbar: false;">
 <![CDATA[
 Problem problem = new DTLZ2(2);
-NSGAII algorithm = new NSGAII(problem);
 
+NSGAII algorithm = new NSGAII(problem);
 algorithm.setInitialPopulationSize(250);
 algorithm.setVariation(new PCX(5, 2));
 algorithm.setArchive(new EpsilonBoxDominanceArchive(0.01));

--- a/website/xslt/examples.xml
+++ b/website/xslt/examples.xml
@@ -160,7 +160,7 @@ Var1     Var2     Var3     Var4     Var5     Var6     Var7     Var8     Var9    
 </p>
 
 <div class="code">
-<!-- java:examples/Example2.java [38:52] -->
+<!-- java:examples/Example2.java [37:49] -->
 <pre class="brush: java; toolbar: false;">
 <![CDATA[
 
@@ -169,14 +169,12 @@ Problem problem = new DTLZ2(2);
 NSGAII algorithm = new NSGAII(problem);
 algorithm.run(10000);
 
-NondominatedPopulation result = algorithm.getResult();
+NondominatedPopulation approximationSet = algorithm.getResult();
 
 NondominatedPopulation referenceSet = PopulationIO.readReferenceSet("pf/DTLZ2.2D.pf");
-Hypervolume hypervolume = new Hypervolume(problem, referenceSet);
-GenerationalDistance gd = new GenerationalDistance(problem, referenceSet);
 
-System.out.format("Hypervolume: %.6f%n", hypervolume.evaluate(result));
-System.out.format("GD: %.6f%n", gd.evaluate(result));
+Indicators indicator = Indicators.all(problem, referenceSet);
+indicator.apply(approximationSet).display();
 ]]>
 </pre>
 </div>
@@ -189,8 +187,18 @@ System.out.format("GD: %.6f%n", gd.evaluate(result));
 <!-- output:examples/Example2.java -->
 <pre class="brush: plain; toolbar: false;">
 <![CDATA[
-Hypervolume: 0.209259
-GD: 0.000987
+Indicator                    Value    
+---------------------------- -------- 
+Hypervolume                  0.209259 
+GenerationalDistance         0.000987 
+InvertedGenerationalDistance 0.004388 
+AdditiveEpsilonIndicator     0.008974 
+Spacing                      0.005820 
+MaximumParetoFrontError      0.039554 
+Contribution                 0.000000 
+R1                           0.471058 
+R2                           0.000258 
+R3                           0.000389 
 ]]>
 </pre>
 </div>

--- a/website/xslt/examples.xml
+++ b/website/xslt/examples.xml
@@ -160,10 +160,9 @@ Var1     Var2     Var3     Var4     Var5     Var6     Var7     Var8     Var9    
 </p>
 
 <div class="code">
-<!-- java:examples/Example2.java [36:48] -->
+<!-- java:examples/Example2.java [37:48] -->
 <pre class="brush: java; toolbar: false;">
 <![CDATA[
-
 Problem problem = new DTLZ2(2);
 
 NSGAII algorithm = new NSGAII(problem);

--- a/website/xslt/examples.xml
+++ b/website/xslt/examples.xml
@@ -173,8 +173,8 @@ NondominatedPopulation approximationSet = algorithm.getResult();
 
 NondominatedPopulation referenceSet = PopulationIO.readReferenceSet("pf/DTLZ2.2D.pf");
 
-Indicators indicator = Indicators.all(problem, referenceSet);
-indicator.apply(approximationSet).display();
+Indicators indicators = Indicators.all(problem, referenceSet);
+indicators.apply(approximationSet).display();
 ]]>
 </pre>
 </div>

--- a/website/xslt/examples.xml
+++ b/website/xslt/examples.xml
@@ -160,7 +160,7 @@ Var1     Var2     Var3     Var4     Var5     Var6     Var7     Var8     Var9    
 </p>
 
 <div class="code">
-<!-- java:examples/Example2.java [37:49] -->
+<!-- java:examples/Example2.java [36:48] -->
 <pre class="brush: java; toolbar: false;">
 <![CDATA[
 


### PR DESCRIPTION
Introduces the `Indicators` class as a replacement for `QualityIndicator`.  The `QualityIndicator` was limited in that it had runtime checks to ensure the `calculate` method was called correctly, and did not include all available metrics (e.g., the R indicators).

The new `Indicators` class makes it easy to compute and display the results.  For example, here we include all available metrics:

```java
Indicators indicators = Indicators.all(problem, referenceSet);
indicators.apply(approximationSet).display();
```

```
Indicator                    Value    
---------------------------- -------- 
Hypervolume                  0.208141 
GenerationalDistance         0.000968 
InvertedGenerationalDistance 0.005345 
AdditiveEpsilonIndicator     0.015835 
Spacing                      0.007349 
MaximumParetoFrontError      0.043370 
Contribution                 0.000000 
R1                           0.421158 
R2                           0.000450 
R3                           0.000682 

```

As a bonus change, also adds a way to scope settings changes.  This is especially useful for writing tests, where we want to undo any changes made during each test case:

```java
try (Scope scope = Settings.createScope().with("temp_setting", "value")) {
   ... temp setting only exists within this block ...
}
```